### PR TITLE
[Design] #8 Add Common TextArea

### DIFF
--- a/Heim/Presentation/Presentation/Common/CommonTextArea.swift
+++ b/Heim/Presentation/Presentation/Common/CommonTextArea.swift
@@ -1,0 +1,137 @@
+//
+//  CommonTextArea.swift
+//  Presentation
+//
+//  Created by 정지용 on 11/7/24.
+//
+
+import UIKit
+import SnapKit
+
+/// CommonTextView는 커스텀한 배경 색상과 오버레이를 갖춘 `UIView`의 서브클래스입니다.
+/// 텍스트를 보여주기 위한 `UILabel`을 포함하며,  텍스트에 따라 가변적으로 높이가 변화하도록 설계되었습니다.
+/// 필요에 따라 생성 시 최소 높이를 설정할 수 있습니다.
+///
+/// UILabel에서 사용될 text를 지정하기 위해 `setText(_ text: String)`를 구현했습니다.
+/// Constraint를 설정하는 경우를 위해 `requiredHeight()`를 구현했고, 자세한 부분은 해당 메소드의 코멘트를 확인해주세요.
+public final class CommonTextArea: UIView {
+  // MARK: - Properties
+  private let gradientLayer = CAGradientLayer()
+  private let whiteOverlayLayer = CALayer()
+  private let minHeight: CGFloat
+  
+  private let textLabel: UILabel = {
+    let textLabel = UILabel()
+    textLabel.numberOfLines = 0
+    textLabel.textAlignment = .left
+    textLabel.textColor = .black
+    textLabel.backgroundColor = .clear
+    return textLabel
+  }()
+  
+  // MARK: - Initializer
+  public init(
+    min height: CGFloat = 0
+  ) {
+    self.minHeight = height
+    super.init(frame: .zero)
+    setupLayers()
+    setupViews()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup, Configuration UI
+private extension CommonTextArea {
+  func setupLayers() {
+    gradientLayer.colors = [UIColor.white.cgColor, UIColor.secondary.cgColor]
+    layer.addSublayer(gradientLayer)
+    whiteOverlayLayer.backgroundColor = UIColor.white.withAlphaComponent(0.6).cgColor
+    layer.addSublayer(whiteOverlayLayer)
+  }
+  
+  func setupViews() {
+    layer.cornerRadius = Constants.cornerRadius
+    layer.masksToBounds = true
+    setupLabel()
+  }
+  
+  func setupLabel() {
+    addSubview(textLabel)
+    textLabel.font = UIFont.regularFont(ofSize: Constants.fontSize)
+    
+    textLabel.snp.makeConstraints { make in
+      make.top.equalToSuperview().inset(Constants.labelPadding)
+      make.leading.equalToSuperview().inset(Constants.labelPadding)
+      make.trailing.equalToSuperview().inset(Constants.labelPadding)
+      make.bottom.equalToSuperview().inset(Constants.labelPadding)
+    }
+  }
+}
+
+// MARK: - Public Methods
+public extension CommonTextArea {
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    gradientLayer.frame = bounds
+    whiteOverlayLayer.frame = bounds
+  }
+  
+  /// 텍스트를 설정하는 메서드입니다.
+  ///
+  /// - Parameter text: 표시할 텍스트
+  func setText(_ text: String) {
+    textLabel.text = text
+    setLineSpacing()
+  }
+  
+  /// 전체 텍스트를 화면에 표시하기 위해 높이를 계산합니다.
+  /// Constraint를 지정할 때 사용하면 됩니다.
+  ///
+  /// Example:
+  /// ```swift
+  /// // SnapKit 사용 시
+  /// make.height.equalTo(commonTextView.requiredHeight())
+  /// ```
+  ///
+  /// - Returns: `minHeight`과 화면에 Text를 완전히 보여주기 위한 크기를 비교하여 CGFloat 값을 반환합니다.
+  func requiredHeight() -> CGFloat {
+    let size = CGSize(width: textLabel.bounds.width, height: .infinity)
+    let estimatedSize = textLabel.sizeThatFits(size)
+    
+    return max(minHeight, estimatedSize.height + 2 * Constants.labelPadding)
+  }
+}
+
+// MARK: - Private Methods
+private extension CommonTextArea {
+  func setLineSpacing(
+    lineHeightMultiple: CGFloat = 1.3
+  ) {
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.lineHeightMultiple = lineHeightMultiple
+    
+    let attributedString = NSAttributedString(
+      string: textLabel.text ?? "",
+      attributes: [
+        .paragraphStyle: paragraphStyle,
+        .font: textLabel.font ?? UIFont.systemFont(ofSize: 16)
+      ]
+    )
+    
+    textLabel.attributedText = attributedString
+  }
+}
+
+// MARK: - Constants
+private extension CommonTextArea {
+  enum Constants {
+    static let cornerRadius: CGFloat = 10
+    static let labelPadding: CGFloat = 16
+    static let fontSize: CGFloat = 16
+  }
+}

--- a/Heim/Presentation/Presentation/Common/CommonTextArea.swift
+++ b/Heim/Presentation/Presentation/Common/CommonTextArea.swift
@@ -8,13 +8,13 @@
 import UIKit
 import SnapKit
 
-/// CommonTextView는 커스텀한 배경 색상과 오버레이를 갖춘 `UIView`의 서브클래스입니다.
+/// CommonTextArea는 커스텀한 배경 색상과 오버레이를 갖춘 `UIView`의 서브클래스입니다.
 /// 텍스트를 보여주기 위한 `UILabel`을 포함하며,  텍스트에 따라 가변적으로 높이가 변화하도록 설계되었습니다.
 /// 필요에 따라 생성 시 최소 높이를 설정할 수 있습니다.
 ///
 /// UILabel에서 사용될 text를 지정하기 위해 `setText(_ text: String)`를 구현했습니다.
-/// Constraint를 설정하는 경우를 위해 `requiredHeight()`를 구현했고, 자세한 부분은 해당 메소드의 코멘트를 확인해주세요.
-public final class CommonTextArea: UIView {
+/// `minHeight`을 사용하며, Constraint를 설정하는 경우를 위해 `requiredHeight()`를 구현했고, 자세한 부분은 해당 메소드의 코멘트를 확인해주세요.
+final class CommonTextArea: UIView {
   // MARK: - Properties
   private let gradientLayer = CAGradientLayer()
   private let whiteOverlayLayer = CALayer()
@@ -42,38 +42,8 @@ public final class CommonTextArea: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-}
-
-// MARK: - Setup, Configuration UI
-private extension CommonTextArea {
-  func setupLayers() {
-    gradientLayer.colors = [UIColor.white.cgColor, UIColor.secondary.cgColor]
-    layer.addSublayer(gradientLayer)
-    whiteOverlayLayer.backgroundColor = UIColor.white.withAlphaComponent(0.6).cgColor
-    layer.addSublayer(whiteOverlayLayer)
-  }
   
-  func setupViews() {
-    layer.cornerRadius = Constants.cornerRadius
-    layer.masksToBounds = true
-    setupLabel()
-  }
-  
-  func setupLabel() {
-    addSubview(textLabel)
-    textLabel.font = UIFont.regularFont(ofSize: Constants.fontSize)
-    
-    textLabel.snp.makeConstraints { make in
-      make.top.equalToSuperview().inset(Constants.labelPadding)
-      make.leading.equalToSuperview().inset(Constants.labelPadding)
-      make.trailing.equalToSuperview().inset(Constants.labelPadding)
-      make.bottom.equalToSuperview().inset(Constants.labelPadding)
-    }
-  }
-}
-
-// MARK: - Public Methods
-public extension CommonTextArea {
+  // MARK: - Methods
   override func layoutSubviews() {
     super.layoutSubviews()
     
@@ -107,6 +77,31 @@ public extension CommonTextArea {
   }
 }
 
+// MARK: - Setup, Configuration UI
+private extension CommonTextArea {
+  func setupLayers() {
+    gradientLayer.colors = [UIColor.white.cgColor, UIColor.secondary.cgColor]
+    layer.addSublayer(gradientLayer)
+    whiteOverlayLayer.backgroundColor = UIColor.white.withAlphaComponent(0.6).cgColor
+    layer.addSublayer(whiteOverlayLayer)
+  }
+  
+  func setupViews() {
+    layer.cornerRadius = Constants.cornerRadius
+    layer.masksToBounds = true
+    setupLabel()
+  }
+  
+  func setupLabel() {
+    addSubview(textLabel)
+    textLabel.font = UIFont.regularFont(ofSize: Constants.fontSize)
+    
+    textLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(Constants.labelPadding)
+    }
+  }
+}
+
 // MARK: - Private Methods
 private extension CommonTextArea {
   func setLineSpacing(
@@ -128,8 +123,8 @@ private extension CommonTextArea {
 }
 
 // MARK: - Constants
-private extension CommonTextArea {
-  enum Constants {
+extension CommonTextArea {
+  private enum Constants {
     static let cornerRadius: CGFloat = 10
     static let labelPadding: CGFloat = 16
     static let fontSize: CGFloat = 16

--- a/Heim/Presentation/Presentation/Common/CommonTextAreaView.swift
+++ b/Heim/Presentation/Presentation/Common/CommonTextAreaView.swift
@@ -1,5 +1,5 @@
 //
-//  CommonTextArea.swift
+//  CommonTextAreaView.swift
 //  Presentation
 //
 //  Created by 정지용 on 11/7/24.
@@ -14,7 +14,7 @@ import SnapKit
 ///
 /// UILabel에서 사용될 text를 지정하기 위해 `setText(_ text: String)`를 구현했습니다.
 /// `minHeight`을 사용하며, Constraint를 설정하는 경우를 위해 `requiredHeight()`를 구현했고, 자세한 부분은 해당 메소드의 코멘트를 확인해주세요.
-final class CommonTextArea: UIView {
+final class CommonTextAreaView: UIView {
   // MARK: - Properties
   private let gradientLayer = CAGradientLayer()
   private let whiteOverlayLayer = CALayer()
@@ -78,7 +78,7 @@ final class CommonTextArea: UIView {
 }
 
 // MARK: - Setup, Configuration UI
-private extension CommonTextArea {
+private extension CommonTextAreaView {
   func setupLayers() {
     gradientLayer.colors = [UIColor.white.cgColor, UIColor.secondary.cgColor]
     layer.addSublayer(gradientLayer)
@@ -103,7 +103,7 @@ private extension CommonTextArea {
 }
 
 // MARK: - Private Methods
-private extension CommonTextArea {
+private extension CommonTextAreaView {
   func setLineSpacing(
     lineHeightMultiple: CGFloat = 1.3
   ) {
@@ -123,7 +123,7 @@ private extension CommonTextArea {
 }
 
 // MARK: - Constants
-extension CommonTextArea {
+extension CommonTextAreaView {
   private enum Constants {
     static let cornerRadius: CGFloat = 10
     static let labelPadding: CGFloat = 16

--- a/Heim/Presentation/Presentation/Common/CommonTextAreaView.swift
+++ b/Heim/Presentation/Presentation/Common/CommonTextAreaView.swift
@@ -30,9 +30,7 @@ final class CommonTextAreaView: UIView {
   }()
   
   // MARK: - Initializer
-  public init(
-    min height: CGFloat = 0
-  ) {
+  public init(min height: CGFloat = 0) {
     self.minHeight = height
     super.init(frame: .zero)
     setupLayers()
@@ -104,17 +102,15 @@ private extension CommonTextAreaView {
 
 // MARK: - Private Methods
 private extension CommonTextAreaView {
-  func setLineSpacing(
-    lineHeightMultiple: CGFloat = 1.3
-  ) {
+  func setLineSpacing() {
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.lineHeightMultiple = lineHeightMultiple
+    paragraphStyle.lineHeightMultiple = Constants.lineHeightMultiple
     
     let attributedString = NSAttributedString(
       string: textLabel.text ?? "",
       attributes: [
         .paragraphStyle: paragraphStyle,
-        .font: textLabel.font ?? UIFont.systemFont(ofSize: 16)
+        .font: textLabel.font ?? UIFont.systemFont(ofSize: Constants.fontSize)
       ]
     )
     
@@ -123,10 +119,11 @@ private extension CommonTextAreaView {
 }
 
 // MARK: - Constants
-extension CommonTextAreaView {
-  private enum Constants {
+private extension CommonTextAreaView {
+  enum Constants {
     static let cornerRadius: CGFloat = 10
     static let labelPadding: CGFloat = 16
     static let fontSize: CGFloat = 16
+    static let lineHeightMultiple: CGFloat = 1.3
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈 번호
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/8
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/13
  - 폰트 미적용 관련 내용입니다.
<br>

# 📘 작업 유형
 - [x] 신규 기능 추가

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
- UIView에 CALayer, CAGradientLayer를 통해 배경화면 구성
- Text의 크기에 맞춰 높이를 지정할 수 있도록 public 메소드 구현

<br>

# 📷 스크린샷
![Simulator Screenshot - iPhone 16 Pro - 2024-11-07 at 17 20 29](https://github.com/user-attachments/assets/fcc5ba0f-1b02-4a5d-9fb7-baa585b8316f)

<br>

### 📝 특이 사항 (Optional)
 - `extension`으로 로직 구분을 하고 관련 주석을 담았는데 다른 분들이 보기에 어떤가요 ? 코드 구분이 잘 되어 눈에 들어오는지 궁금하네요. 리뷰 부탁드립니다.
 - 실질적으로 이 View를 내가 아닌 다른 사람이 사용할 때, 사용법을 어떻게 해야 할지 애매할 수 있겠다 싶어 관련 주석을 예제와 함께 추가했습니다.

<img width="567" alt="스크린샷 2024-11-07 17 33 42" src="https://github.com/user-attachments/assets/d9d63ca9-bbdd-480e-a774-ea660dd9bfdf">

<br>

- 마지막 부분을 수정하지 않은 이유 ?

```swift
func requiredHeight() -> CGFloat {
  let size = CGSize(width: textLabel.bounds.width, height: .infinity)
  let estimatedSize = textLabel.sizeThatFits(size)
  return max(minHeight, estimatedSize.height + 2 * Constants.labelPadding)
}
```

- 이 부분은 PR 메시지를 보고도, 수정하지 않았습니다. 다시 곰곰히 생각해봤는데요,
- 일반적으로는 높이를 지정하고 사용하는 View가 아니라고 생각합니다. 보통은 Width에 제약을 두고 사용할거라고 생각하는데요, 이런 경우에는 UILabel의 상진님의 말씀대로 제약에 따라 자동으로 높이가 계산됩니다.
- 여기서 `requiredHeight()`를 사용하는 이유는`minHeight`에 따라 정해집니다. 이 뷰를 사용하는 입장에서, 레이아웃을 고민할 때 조금 더 자유도를 부여했다고 생각하시면 좋습니다. `minHeight`은 없어도 되는 인자이고, 이를 지정하지 않았다면 사용할 이유가 없죠. 
  즉, minHeight을 사용해서 TextArea에 공백을 넣고자 하는 경우에만 사용한다고 생각합니다. 그래서 주석도 달았구요. 참고 바랍니다.