### PR TITLE
[Refactor] HomeUI 리팩토링

### DIFF
--- a/Heim/Presentation/Presentation/Extension/UIColor+.swift
+++ b/Heim/Presentation/Presentation/Extension/UIColor+.swift
@@ -35,4 +35,11 @@ extension UIColor {
     blue: 234 / 255,
     alpha: 1.0
   )
+
+  static let whiteGray = UIColor(
+    red:  233 / 255.0,
+    green: 235 / 255.0,
+    blue: 137 / 255.0,
+    alpha: 0.3
+  )
 }

--- a/Heim/Presentation/Presentation/Home/CalendarCell.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarCell.swift
@@ -65,7 +65,7 @@ class CalendarCell: UICollectionViewCell {
   
   func update(day: String) {
     //TODO: 수정필요 - 애초에 View가 그려지지 않도록 하는 방법 찾기
-    self.emojiView.backgroundColor = day.isEmpty ? .clear : UIColor(red: 173 / 255, green: 170 / 255, blue: 195 / 255, alpha: 0.7)
+    self.emojiView.backgroundColor = day.isEmpty ? .clear : .whiteGray
     self.dateLabel.text = day
   }
 }

--- a/Heim/Presentation/Presentation/Home/CalendarCell.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarCell.swift
@@ -15,14 +15,14 @@ class CalendarCell: UICollectionViewCell {
   private let dateLabel: UILabel = {
     let label = UILabel()
     label.textAlignment = .center
-    label.font = UIFont.regularFont(ofSize: 12)
+    label.font = UIFont.regularFont(ofSize: LayoutContants.fontSize)
     label.textColor = .white
     return label
   }()
 
   private let emojiView: UIView = {
     let view = UIView()
-    view.frame.size = CGSize(width: 40, height: 40)
+    view.frame.size = CGSize(width: LayoutContants.emojiSize, height: LayoutContants.emojiSize)
     view.layer.cornerRadius = view.frame.width / 2
     return view
   }()
@@ -59,7 +59,7 @@ class CalendarCell: UICollectionViewCell {
     }
 
     emojiView.snp.makeConstraints {
-      $0.height.equalTo(40)
+      $0.height.equalTo(LayoutContants.emojiSize)
     }
   }
   
@@ -67,5 +67,13 @@ class CalendarCell: UICollectionViewCell {
     //TODO: 수정필요 - 애초에 View가 그려지지 않도록 하는 방법 찾기
     self.emojiView.backgroundColor = day.isEmpty ? .clear : .whiteGray
     self.dateLabel.text = day
+  }
+}
+
+private extension CalendarCell {
+  enum LayoutContants {
+    static let fontSize: CGFloat = 14
+    static let emojiSize: CGFloat = 40
+
   }
 }

--- a/Heim/Presentation/Presentation/Home/CalendarView.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarView.swift
@@ -18,7 +18,7 @@ final class CalendarView: UIView {
   // MARK: - UI Components
   private let yearLabel: UILabel = {
     let label = UILabel()
-    label.font = UIFont.boldFont(ofSize: LayoutContants.boldFontSizeOne)
+    label.font = UIFont.boldFont(ofSize: LayoutContants.yearFontSize)
     label.textColor = .white
     return label
   }()
@@ -50,7 +50,7 @@ final class CalendarView: UIView {
   private let monthLabel: UILabel = {
     let label = UILabel()
     label.textAlignment = .center
-    label.font = UIFont.boldFont(ofSize: LayoutContants.boldFontSizeTwo)
+    label.font = UIFont.boldFont(ofSize: LayoutContants.monthFontSize)
     label.textColor = .white
     return label
   }()
@@ -127,7 +127,8 @@ final class CalendarView: UIView {
 
     weekStackView.snp.makeConstraints {
       $0.top.equalTo(monthStackView.snp.bottom).offset(LayoutContants.weekStackViewTop)
-      $0.width.equalTo(UIScreen.main.bounds.width - 48)
+      //TODO: 익스텐션 추후 적용
+      $0.width.equalTo(UIScreen.main.bounds.width - LayoutContants.weekStackPadding)
       $0.centerX.equalToSuperview()
     }
 
@@ -142,6 +143,7 @@ final class CalendarView: UIView {
       $0.top.equalTo(separatorLineView).offset(LayoutContants.dayCollectionViewTop)
       $0.left.equalToSuperview().offset(LayoutContants.stackViewLeftPadding)
       $0.right.equalToSuperview().offset(LayoutContants.stackViewLeftPadding * -1)
+      //TODO: 익스텐션 추후 적용
       $0.height.equalTo(UIScreen.main.bounds.height * 1 / 2 )
     }
   }
@@ -155,7 +157,7 @@ final class CalendarView: UIView {
       label.text = day.rawValue
       label.textAlignment = .center
       label.textColor = .white
-      label.font = UIFont.boldSystemFont(ofSize: LayoutContants.boldFontSizeFour)
+      label.font = UIFont.boldSystemFont(ofSize: LayoutContants.dayFontSize)
 
       weekStackView.addArrangedSubview(label)
 
@@ -300,10 +302,10 @@ extension CalendarView {
 private extension CalendarView {
   enum LayoutContants {
     static let defaultPadding: CGFloat = 16
-    static let boldFontSizeOne: CGFloat = 28
-    static let boldFontSizeTwo: CGFloat = 24
-    static let boldFontSizeThree: CGFloat = 20
-    static let boldFontSizeFour: CGFloat = 14
+    static let weekStackPadding: CGFloat = 48
+    static let yearFontSize: CGFloat = 28
+    static let monthFontSize: CGFloat = 24
+    static let dayFontSize: CGFloat = 14
     static let buttonSize: CGFloat = 24
     static let stackViewLeftPadding: CGFloat = 24
     static let lineHeight: CGFloat = 1

--- a/Heim/Presentation/Presentation/Home/CalendarView.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarView.swift
@@ -18,15 +18,25 @@ final class CalendarView: UIView {
   // MARK: - UI Components
   private let yearLabel: UILabel = {
     let label = UILabel()
-    label.font = UIFont.boldFont(ofSize: CGFloat(28))
+    label.font = UIFont.boldFont(ofSize: LayoutContants.boldFontSizeOne)
     label.textColor = .white
     return label
   }()
 
+  private let monthStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.distribution = .fillProportionally
+    stackView.alignment = .center
+    return stackView
+  }()
+
   private let previousMonthButton: UIButton = {
     let button = UIButton()
+    //TODO: 에셋 파일 추가
     button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
     button.tintColor = .white
+    //TODO: 버튼 이미지 24 x 24로 꽉차게 적용 
     return button
   }()
 
@@ -40,7 +50,7 @@ final class CalendarView: UIView {
   private let monthLabel: UILabel = {
     let label = UILabel()
     label.textAlignment = .center
-    label.font = UIFont.boldFont(ofSize: CGFloat(24))
+    label.font = UIFont.boldFont(ofSize: LayoutContants.boldFontSizeTwo)
     label.textColor = .white
     return label
   }()
@@ -49,14 +59,12 @@ final class CalendarView: UIView {
     let stackView = UIStackView()
     stackView.axis = .horizontal
     stackView.distribution = .fillEqually
-    stackView.spacing = 38
     return stackView
   }()
 
-  //TODO: 길이를 고정값으로 할지 결정 필요
   private let separatorLineView: UIView = {
     let view = UIView()
-    view.backgroundColor = UIColor(red: 233 / 255.0, green: 235 / 255.0, blue: 137 / 255.0 , alpha: 0.3)
+    view.backgroundColor = .whiteGray
     return view
   }()
 
@@ -74,6 +82,7 @@ final class CalendarView: UIView {
     super.init(frame: frame)
     setupViews()
     setupLayoutConstraints()
+    setupMonthStackView()
     setupWeekStackView()
     setupCollectionView()
     configureCalendar()
@@ -86,6 +95,7 @@ final class CalendarView: UIView {
   // MARK: - Methods
   func setupViews() {
     addSubview(yearLabel)
+    addSubview(monthStackView)
     addSubview(previousMonthButton)
     addSubview(nextMonthButton)
     addSubview(monthLabel)
@@ -97,49 +107,44 @@ final class CalendarView: UIView {
   func setupLayoutConstraints() {
 
     yearLabel.snp.makeConstraints {
-      $0.top.equalTo(self).offset(92)
-      $0.left.equalTo(self).offset(16)
+      $0.top.equalTo(self.safeAreaLayoutGuide)
+      $0.left.equalTo(self).offset(LayoutContants.defaultPadding)
     }
 
     previousMonthButton.snp.makeConstraints {
-      $0.left.equalTo(self).offset(134)
-      $0.top.equalTo(self).offset(132)
-      $0.width.equalTo(17)
-      $0.height.equalTo(19)
-    }
-
-    monthLabel.snp.makeConstraints {
-      $0.left.equalTo(previousMonthButton.snp.right).offset(14)
-      $0.right.equalTo(nextMonthButton.snp.left).offset(-14)
-      $0.centerY.equalTo(previousMonthButton)
+      $0.width.equalTo(LayoutContants.buttonSize)
+      $0.height.equalTo(LayoutContants.buttonSize)
     }
 
     nextMonthButton.snp.makeConstraints {
-      $0.left.equalTo(self).offset(239)
-      $0.top.equalTo(self).offset(132)
-      $0.width.equalTo(17)
-      $0.height.equalTo(19)
+      $0.width.equalTo(LayoutContants.buttonSize)
+      $0.height.equalTo(LayoutContants.buttonSize)
+    }
+
+    monthStackView.snp.makeConstraints {
+      $0.top.equalTo(yearLabel.snp.bottom).offset(LayoutContants.defaultPadding)
+      $0.left.equalTo(yearLabel.snp.right).offset(LayoutContants.stackViewLeftPadding * -1)
+      $0.centerX.equalTo(self)
     }
 
     weekStackView.snp.makeConstraints {
-      $0.top.equalTo(self).offset(199)
-      $0.width.equalTo(dayCollectionView).inset(12)
-      $0.height.equalTo(18)
+      $0.top.equalTo(monthStackView.snp.bottom).offset(LayoutContants.weekStackViewTop)
+      $0.width.equalTo(UIScreen.main.bounds.width - 48)
       $0.centerX.equalTo(self)
     }
 
     separatorLineView.snp.makeConstraints {
-      $0.width.equalTo(317)
-      $0.height.equalTo(1)
-      $0.top.equalTo(weekStackView.snp.bottom).offset(3.75)
+      $0.width.equalTo(weekStackView)
+      $0.height.equalTo(LayoutContants.lineHeight)
+      $0.top.equalTo(weekStackView.snp.bottom).offset(LayoutContants.lineViewBottom)
       $0.centerX.equalTo(self)
     }
-
+    
     dayCollectionView.snp.makeConstraints {
-      $0.top.equalTo(self).offset(228)
-      $0.left.equalTo(self).offset(24)
-      $0.right.equalTo(self).offset(-24)
-      $0.height.equalTo(490)
+      $0.top.equalTo(separatorLineView).offset(LayoutContants.dayCollectionViewTop)
+      $0.left.equalTo(self).offset(LayoutContants.stackViewLeftPadding)
+      $0.right.equalTo(self).offset(LayoutContants.stackViewLeftPadding * -1)
+      $0.height.equalTo(UIScreen.main.bounds.height * 1 / 2 )
     }
   }
 
@@ -152,7 +157,7 @@ final class CalendarView: UIView {
       label.text = day.rawValue
       label.textAlignment = .center
       label.textColor = .white
-      label.font = UIFont.boldSystemFont(ofSize: 14)
+      label.font = UIFont.boldSystemFont(ofSize: LayoutContants.boldFontSizeFour)
 
       weekStackView.addArrangedSubview(label)
 
@@ -162,6 +167,12 @@ final class CalendarView: UIView {
         label.textColor = .blue
       }
     }
+  }
+  //MARK: - MonthStackViewUI
+  private func setupMonthStackView() {
+    monthStackView.addArrangedSubview(previousMonthButton)
+    monthStackView.addArrangedSubview(monthLabel)
+    monthStackView.addArrangedSubview(nextMonthButton)
   }
 }
 
@@ -198,7 +209,7 @@ extension CalendarView: UICollectionViewDataSource, UICollectionViewDelegate, UI
     sizeForItemAt indexPath: IndexPath
   ) -> CGSize {
     let width = dayCollectionView.frame.width / 9
-    return CGSize(width: width, height: 80)
+    return CGSize(width: width, height: dayCollectionView.bounds.height / 5)
   }
 
   public func collectionView(
@@ -288,4 +299,18 @@ extension CalendarView {
   }
 }
 
-
+private extension CalendarView {
+  enum LayoutContants {
+    static let defaultPadding: CGFloat = 16
+    static let boldFontSizeOne: CGFloat = 28
+    static let boldFontSizeTwo: CGFloat = 24
+    static let boldFontSizeThree: CGFloat = 20
+    static let boldFontSizeFour: CGFloat = 14
+    static let buttonSize: CGFloat = 24
+    static let stackViewLeftPadding: CGFloat = 24
+    static let lineHeight: CGFloat = 1
+    static let lineViewBottom: CGFloat = 4
+    static let dayCollectionViewTop: CGFloat = 10
+    static let weekStackViewTop: CGFloat = 30
+  }
+}

--- a/Heim/Presentation/Presentation/Home/CalendarView.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarView.swift
@@ -93,7 +93,7 @@ final class CalendarView: UIView {
   }
 
   // MARK: - Methods
-  func setupViews() {
+  private func setupViews() {
     addSubview(yearLabel)
     addSubview(monthStackView)
     addSubview(previousMonthButton)
@@ -104,8 +104,7 @@ final class CalendarView: UIView {
     addSubview(dayCollectionView)
   }
 
-  func setupLayoutConstraints() {
-
+  private func setupLayoutConstraints() {
     yearLabel.snp.makeConstraints {
       $0.top.equalTo(self.safeAreaLayoutGuide)
       $0.left.equalTo(self).offset(LayoutContants.defaultPadding)

--- a/Heim/Presentation/Presentation/Home/CalendarView.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarView.swift
@@ -107,7 +107,7 @@ final class CalendarView: UIView {
   private func setupLayoutConstraints() {
     yearLabel.snp.makeConstraints {
       $0.top.equalTo(self.safeAreaLayoutGuide)
-      $0.left.equalTo(self).offset(LayoutContants.defaultPadding)
+      $0.left.equalToSuperview().offset(LayoutContants.defaultPadding)
     }
 
     previousMonthButton.snp.makeConstraints {
@@ -123,26 +123,27 @@ final class CalendarView: UIView {
     monthStackView.snp.makeConstraints {
       $0.top.equalTo(yearLabel.snp.bottom).offset(LayoutContants.defaultPadding)
       $0.left.equalTo(yearLabel.snp.right).offset(LayoutContants.stackViewLeftPadding * -1)
-      $0.centerX.equalTo(self)
+      $0.centerX.equalToSuperview()
     }
 
     weekStackView.snp.makeConstraints {
       $0.top.equalTo(monthStackView.snp.bottom).offset(LayoutContants.weekStackViewTop)
       $0.width.equalTo(UIScreen.main.bounds.width - 48)
-      $0.centerX.equalTo(self)
+      $0.centerX.equalToSuperview()
+      $0.centerX.equalToSuperview()
     }
 
     separatorLineView.snp.makeConstraints {
       $0.width.equalTo(weekStackView)
       $0.height.equalTo(LayoutContants.lineHeight)
       $0.top.equalTo(weekStackView.snp.bottom).offset(LayoutContants.lineViewBottom)
-      $0.centerX.equalTo(self)
+      $0.centerX.equalToSuperview()
     }
     
     dayCollectionView.snp.makeConstraints {
       $0.top.equalTo(separatorLineView).offset(LayoutContants.dayCollectionViewTop)
-      $0.left.equalTo(self).offset(LayoutContants.stackViewLeftPadding)
-      $0.right.equalTo(self).offset(LayoutContants.stackViewLeftPadding * -1)
+      $0.left.equalToSuperview().offset(LayoutContants.stackViewLeftPadding)
+      $0.right.equalToSuperview().offset(LayoutContants.stackViewLeftPadding * -1)
       $0.height.equalTo(UIScreen.main.bounds.height * 1 / 2 )
     }
   }

--- a/Heim/Presentation/Presentation/Home/CalendarView.swift
+++ b/Heim/Presentation/Presentation/Home/CalendarView.swift
@@ -122,14 +122,12 @@ final class CalendarView: UIView {
 
     monthStackView.snp.makeConstraints {
       $0.top.equalTo(yearLabel.snp.bottom).offset(LayoutContants.defaultPadding)
-      $0.left.equalTo(yearLabel.snp.right).offset(LayoutContants.stackViewLeftPadding * -1)
       $0.centerX.equalToSuperview()
     }
 
     weekStackView.snp.makeConstraints {
       $0.top.equalTo(monthStackView.snp.bottom).offset(LayoutContants.weekStackViewTop)
       $0.width.equalTo(UIScreen.main.bounds.width - 48)
-      $0.centerX.equalToSuperview()
       $0.centerX.equalToSuperview()
     }
 

--- a/Heim/Presentation/Presentation/Home/HomeViewController.swift
+++ b/Heim/Presentation/Presentation/Home/HomeViewController.swift
@@ -27,12 +27,12 @@ public class HomeViewController: UIViewController {
   }
 
   // MARK: - Methods
-  func setupViews() {
+  private func setupViews() {
     view.addSubview(backgroundImageView)
     view.addSubview(calendarView)
   }
 
-  func setupLayoutConstraints() {
+  private func setupLayoutConstraints() {
     backgroundImageView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }

--- a/Heim/Presentation/Presentation/Home/HomeViewController.swift
+++ b/Heim/Presentation/Presentation/Home/HomeViewController.swift
@@ -42,4 +42,3 @@ public class HomeViewController: UIViewController {
     }
   }
 }
-

--- a/Heim/Presentation/Presentation/Home/HomeViewController.swift
+++ b/Heim/Presentation/Presentation/Home/HomeViewController.swift
@@ -15,7 +15,7 @@ public class HomeViewController: UIViewController {
 
   private let backgroundImageView: UIImageView = {
     let imageView = UIImageView()
-    imageView.image = UIImage(named: "Background")
+    imageView.image = .background
     imageView.contentMode = .scaleAspectFill
     return imageView
   }()


### PR DESCRIPTION
### 📌 관련 이슈 번호 ex) #이슈번호
#1 
<br>
    
# 📘 작업 유형
- [x] 코드 리팩토링
- [ ] Sfsymbol 에셋 파일 추가 
<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
- HomeUI 레이아웃 수정 
- 기존에 쓰이던 상수값들을 최대한 사용하지 않도록 전반적인 코드 리팩토링 
<br>

| iPhone SE | iPhone 16 Pro |
| ------------ | ------------- |
| ![스크린샷 2024-11-13 오후 3 04 50](https://github.com/user-attachments/assets/35b9423d-e480-46ff-8e51-c1f419a06892) | ![스크린샷 2024-11-13 오후 3 08 09](https://github.com/user-attachments/assets/41b9f643-f8bc-402c-91e0-3aa85ced9e0a)  |


### 📝 특이 사항 (Optional)
- 기존에는 figma에서 가져온 상수값을 그대로 사용하려 레이아웃을 잡았습니다. 
- 피드백 받은대로 크게 묶일 수 있는 뷰들은 stack 뷰로 묶어주고, 레이아웃 잡을때는 최대한 뷰와 뷰끼리의 제약 조건을 잡을 수 있도록 개선했습니다! 
![스크린샷 2024-11-13 오후 3 13 26](https://github.com/user-attachments/assets/1da4ce65-1069-44ec-b9d0-8774672c130b)
- LayoutContants을 생성을 했는데 안에 네이밍이 적절한지 의문입니다.. 
- boldFont의 경우 사이즈가 4가지가 들어가서 boldFontSizeOne, boldFontSizeTwo,,, 이런식으로 지었는데,, 보시기에 어떠신가요?!