### PR TITLE
[Feat] 음성 녹음 데이터를 다음화면으로 전달

### DIFF
--- a/Heim/Presentation/Presentation/Record/RecordFeature/Coordinator/RecordCoordinator.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/Coordinator/RecordCoordinator.swift
@@ -10,7 +10,7 @@ import Domain
 import UIKit
 
 public protocol RecordCoordinator: Coordinator {
-  // TODO: 기능필요시 추후 구현
+  func pushEmotionAnalyzeView(voice: Voice?)
 }
 
 public final class DefaultRecordCoordinator: RecordCoordinator {
@@ -35,7 +35,9 @@ public final class DefaultRecordCoordinator: RecordCoordinator {
     parentCoordinator?.removeChild(self)
   }
   
-  // TODO: 프로토콜에서 추가 기능 명시 후 구현
+  public func pushEmotionAnalyzeView(voice: Voice?) {
+    // TODO: EmotionAnlyzeView와 연결
+  }
 }
 
 // MARK: - Private

--- a/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
@@ -89,7 +89,7 @@ extension RecordViewController: RecordViewDelegate {
       viewModel.action(.refresh)
     case .next:
       // TODO: 다음 화면으로 이동
-      coordinator?.pushEmotionAnalyzeView(voice: viewModel.state.voiceData)
+      coordinator?.pushEmotionAnalyzeView(voice: viewModel.voiceData())
     case .close:
       // TODO: 추후 화면 연결시 동작 확인 필요
       coordinator?.didFinish()

--- a/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
@@ -88,7 +88,8 @@ extension RecordViewController: RecordViewDelegate {
     case .refresh:
       viewModel.action(.refresh)
     case .next:
-      viewModel.action(.moveToNext)
+      // TODO: 다음 화면으로 이동
+      coordinator?.pushEmotionAnalyzeView(voice: viewModel.state.voiceData)
     case .close:
       // TODO: 추후 화면 연결시 동작 확인 필요
       coordinator?.didFinish()

--- a/Heim/Presentation/Presentation/Record/RecordFeature/ViewModel/RecordViewModel.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/ViewModel/RecordViewModel.swift
@@ -16,14 +16,14 @@ final class RecordViewModel: ViewModel {
     case startRecording
     case stopRecording
     case refresh
-    case moveToNext
   }
   
-  struct State: Equatable {
+  struct State {
     var isRecording: Bool = false
     var canMoveToNext: Bool = false
     var timeText: String = "00:00"
     var isPaused: Bool = false
+    var voiceData: Voice?
   }
   
   @Published var state: State
@@ -49,8 +49,6 @@ final class RecordViewModel: ViewModel {
       handleStopRecording()
     case .refresh:
       handleRefresh()
-    case .moveToNext:
-      handleMoveToNext()
     }
   }
 }
@@ -73,6 +71,7 @@ private extension RecordViewModel {
     state.isRecording = false
     state.canMoveToNext = true
     state.isPaused = true
+    state.voiceData = recordManager.voice
     stopTimeObservation()
   }
   
@@ -80,11 +79,6 @@ private extension RecordViewModel {
     recordManager.resetAll()
     stopTimeObservation()
     state = State()
-  }
-  
-  func handleMoveToNext() {
-    recordManager.resetAll()
-    // TODO: 다음 화면과 연결
   }
   
   func startTimeObservation() {

--- a/Heim/Presentation/Presentation/Record/RecordFeature/ViewModel/RecordViewModel.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/ViewModel/RecordViewModel.swift
@@ -22,13 +22,14 @@ final class RecordViewModel: ViewModel {
     var isRecording: Bool = false
     var canMoveToNext: Bool = false
     var timeText: String = "00:00"
-    var isPaused: Bool = false
-    var voiceData: Voice?
   }
   
   @Published var state: State
   private var recordManager: RecordManager
   private var timer: Timer?
+  
+  private var isPaused: Bool = false
+  private var voice: Voice?
   
   // MARK: - Initializer
   init() {
@@ -51,6 +52,10 @@ final class RecordViewModel: ViewModel {
       handleRefresh()
     }
   }
+  
+  func voiceData() -> Voice? {
+    return voice
+  }
 }
 
 // MARK: - Private Extenion
@@ -70,8 +75,8 @@ private extension RecordViewModel {
     recordManager.stopRecording()
     state.isRecording = false
     state.canMoveToNext = true
-    state.isPaused = true
-    state.voiceData = recordManager.voice
+    isPaused = true
+    voice = recordManager.voice
     stopTimeObservation()
   }
   
@@ -84,10 +89,10 @@ private extension RecordViewModel {
   func startTimeObservation() {
     stopTimeObservation()
     
-    if !state.isPaused {
+    if isPaused {
       state.timeText = "00:00"
     }
-    state.isPaused = false
+    isPaused = false
     
     timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
       guard let self = self else { return }


### PR DESCRIPTION
### 📌 관련 이슈 번호

- #54 

<br>

# 📘 작업 유형
 - [x] 신규 기능 추가
 - [x] 기존 로직 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - 기존 AVAudioRecorder를 이용해 녹음을 진행하던 방식을 수정하였습니다,
     - AVAudioRecorder는 파일 기반 녹음 API -> 녹음 중지 시 특정 파일 영역에 음성 녹음이 존재

 - AVAudioEngine을 이용하여 음성 데이터를 메모리에서 관리하도록 수정하였습니다.
     - AVAudioEngine에서는 오디오 데이터가 PCM 형식으로 들어옵니다.
     - 실시간으로 들어오는 PCM 오디오 데이터를 Data 형식으로 변환하여 저장

- RecordManager 에서 저장되는 Data 타입의 오디오 정보는 voice 라는 프로퍼티에 저장이 되고, 이를 다음 화면에 전달을 하도록 수정했습니다.

## 실행 영상
- 현재 요구사항은 아니지만, 작업중인 화면에서 음성 녹음을 Data 타입으로 변환한 뒤, 다시금 디바이스에서 재생해보는 영상입니다. 
    - **제 목소리가 나오니 소리 주의 바랍니다**

https://github.com/user-attachments/assets/ca97af38-5ae4-403b-bdb5-a8a5eeeb404a


<br>

### 📝 특이 사항 (Optional)
 - 오디오를 다루는 과정에서 해당 개념을 깊게 파고 들기 시작할 시, 시간이 부족할 것 같다고 판단하여 깊이 있는 학습을 진행하지 못한 채, 기능 구현을 진행하였습니다.

 - 아래의 레퍼런스를 참고하였습니다.
     - [how to play sound with AVAudioPCMBuffer](https://stackoverflow.com/questions/26670756/how-to-play-sound-with-avaudiopcmbuffer)

<br>