### PR TITLE
[Feat] 감정 분석(2-1) 화면 구현

### DIFF
--- a/Heim/Domain/Domain/UseCase/EmotionClassifyUseCase.swift
+++ b/Heim/Domain/Domain/UseCase/EmotionClassifyUseCase.swift
@@ -7,12 +7,14 @@
 
 import CoreML
 
-protocol EmotionClassifyUseCase {
+public protocol EmotionClassifyUseCase {
   func validate(_ input: String) async throws -> Emotion
 }
 
-struct DefaultEmotionClassifyUseCase: EmotionClassifyUseCase {
-  func validate(_ input: String) async throws -> Emotion {
+public struct DefaultEmotionClassifyUseCase: EmotionClassifyUseCase {
+  public init() {}
+  
+  public func validate(_ input: String) async throws -> Emotion {
     let model = try EmotionClassifier(configuration: MLModelConfiguration())
     let result = try model.prediction(text: input)
     return Emotion(rawValue: result.label) ?? .none

--- a/Heim/Presentation/Presentation/Extension/UIColor+.swift
+++ b/Heim/Presentation/Presentation/Extension/UIColor+.swift
@@ -49,4 +49,11 @@ extension UIColor {
     blue: 137 / 255.0,
     alpha: 0.3
   )
+  
+  static let primaryTransparent = UIColor(
+    red: 28 / 255,
+    green: 7 / 255,
+    blue: 93 / 255,
+    alpha: 0.5
+  )
 }

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
@@ -11,8 +11,8 @@ import UIKit
 
 public protocol EmotionAnalyzeCoordinator: Coordinator {
   // MARK: - RecordView에서 넘어올 때 요약된 text, Voice Data를 가지고 넘어옵니다.
-  func start(text: String, voice: Voice)
-  func pushDiaryReportView(diary: Diary)
+  func start(recognizedtext: String, voice: Voice)
+  func pushDiaryReportView(emotion: Emotion, heimReply: EmotionReport, voice: Voice)
 }
 
 public final class DefaultEmotionAnalyzeRecordCoordinator: EmotionAnalyzeCoordinator {
@@ -29,18 +29,18 @@ public final class DefaultEmotionAnalyzeRecordCoordinator: EmotionAnalyzeCoordin
   // MARK: - Methods
   public func start() {}
   
-  public func start(text: String, voice: Voice) {
-    guard let emotionAnalyzeViewController = createEmotionAnalyzeViewController(text: text, voice: voice) else {
+  public func start(recognizedtext: String, voice: Voice) {
+    guard let viewController = createEmotionAnalyzeViewController(text: recognizedtext, voice: voice) else {
       return
     }
-    navigationController.pushViewController(emotionAnalyzeViewController, animated: true)
+    navigationController.pushViewController(viewController, animated: true)
   }
   
   public func didFinish() {
     parentCoordinator?.removeChild(self)
   }
   
-  public func pushDiaryReportView(diary: Diary) {
+  public func pushDiaryReportView(emotion: Emotion, heimReply: EmotionReport, voice: Voice) {
     // TODO: 분석 결과 화면으로 이동
   }
 }
@@ -52,8 +52,14 @@ private extension DefaultEmotionAnalyzeRecordCoordinator {
     guard let emotionClassfiyUseCase = DIContainer.shared.resolve(type: EmotionClassifyUseCase.self) else {
       return nil
     }
+    
     // TODO: - viewModel에 추가로 인자를 생성 후 넣어줘야함.
-    let viewModel = EmotionAnalyzeViewModel(recognizedText: text, classifyUseCase: emotionClassfiyUseCase)
+    let viewModel = EmotionAnalyzeViewModel(
+      recognizedText: text,
+      voice: voice,
+      classifyUseCase: emotionClassfiyUseCase
+    )
+    
     let viewController = EmotionAnalyzeViewController(viewModel: viewModel)
     viewController.coordinator = self
     return viewController

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
@@ -1,0 +1,61 @@
+//
+//  EmotionAnalyzeCoordinator.swift
+//  Presentation
+//
+//  Created by 박성근 on 11/23/24.
+//
+
+import Core
+import Domain
+import UIKit
+
+public protocol EmotionAnalyzeCoordinator: Coordinator {
+  // MARK: - RecordView에서 넘어올 때 요약된 text, Voice Data를 가지고 넘어옵니다.
+  func start(text: String, voice: Voice)
+  func pushDiaryReportView(diary: Diary)
+}
+
+public final class DefaultEmotionAnalyzeRecordCoordinator: EmotionAnalyzeCoordinator {
+  // MARK: - Properties
+  public weak var parentCoordinator: Coordinator?
+  public var childCoordinators: [Coordinator] = []
+  public var navigationController: UINavigationController
+  
+  // MARK: - Initialize
+  public init(navigationController: UINavigationController) {
+    self.navigationController = navigationController
+  }
+  
+  // MARK: - Methods
+  public func start() {}
+  
+  public func start(text: String, voice: Voice) {
+    guard let emotionAnalyzeViewController = createEmotionAnalyzeViewController(text: text, voice: voice) else {
+      return
+    }
+    navigationController.pushViewController(emotionAnalyzeViewController, animated: true)
+  }
+  
+  public func didFinish() {
+    parentCoordinator?.removeChild(self)
+  }
+  
+  public func pushDiaryReportView(diary: Diary) {
+    // TODO: 분석 결과 화면으로 이동
+  }
+}
+
+// MARK: - Private
+private extension DefaultEmotionAnalyzeRecordCoordinator {
+  func createEmotionAnalyzeViewController(text: String, voice: Voice) -> EmotionAnalyzeViewController? {
+    // TODO: - TODO: GEMINI UseCase도 추가 해야함.
+    guard let emotionClassfiyUseCase = DIContainer.shared.resolve(type: EmotionClassifyUseCase.self) else {
+      return nil
+    }
+    // TODO: - viewModel에 추가로 인자를 생성 후 넣어줘야함.
+    let viewModel = EmotionAnalyzeViewModel(recognizedText: text, classifyUseCase: emotionClassfiyUseCase)
+    let viewController = EmotionAnalyzeViewController(viewModel: viewModel)
+    viewController.coordinator = self
+    return viewController
+  }
+}

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/Coordinator/EmotionAnalyzeCoordinator.swift
@@ -12,7 +12,7 @@ import UIKit
 public protocol EmotionAnalyzeCoordinator: Coordinator {
   // MARK: - RecordView에서 넘어올 때 요약된 text, Voice Data를 가지고 넘어옵니다.
   func start(recognizedtext: String, voice: Voice)
-  func pushDiaryReportView(emotion: Emotion, heimReply: EmotionReport, voice: Voice)
+  func pushDiaryReportView(diary: Diary)
 }
 
 public final class DefaultEmotionAnalyzeRecordCoordinator: EmotionAnalyzeCoordinator {
@@ -40,7 +40,7 @@ public final class DefaultEmotionAnalyzeRecordCoordinator: EmotionAnalyzeCoordin
     parentCoordinator?.removeChild(self)
   }
   
-  public func pushDiaryReportView(emotion: Emotion, heimReply: EmotionReport, voice: Voice) {
+  public func pushDiaryReportView(diary: Diary) {
     // TODO: 분석 결과 화면으로 이동
   }
 }

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeView.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeView.swift
@@ -1,0 +1,122 @@
+//
+//  EmotionAnalyzeView.swift
+//  Presentation
+//
+//  Created by 박성근 on 11/23/24.
+//
+
+import UIKit
+import SnapKit
+
+protocol EmotionAnalyzeViewDelegate: AnyObject {
+  func buttonDidTap(
+    _ emotionAnalyzeView: EmotionAnalyzeView
+  )
+}
+
+final class EmotionAnalyzeView: UIView {
+  // MARK: - Properties
+  private let screenHeight = UIApplication.screenHeight
+  weak var delegate: EmotionAnalyzeViewDelegate?
+  
+  private let characterImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.image = .recordRabbit
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+  
+  private let descriptionLabel: CommonLabel = CommonLabel(
+    font: .regular,
+    size: LayoutConstants.body1
+  )
+  
+  private let nextButton: CommonRectangleButton = CommonRectangleButton(
+    title: "분석 결과 확인하기!",
+    fontStyle: .boldFont(ofSize: LayoutConstants.body1),
+    backgroundColor: .primaryTransparent
+  )
+  
+  // MARK: - Initialize
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupViews()
+    setupLayoutConstraints()
+    setupActions()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - UI Logic Methods
+  func updatedescriptionLabel(isAnalyzing: Bool) {
+    if isAnalyzing {
+      descriptionLabel.text = "하임이가 열심히 일기를 분석하고 있어요..."
+    } else {
+      descriptionLabel.text = "완료되었어요!"
+    }
+  }
+  
+  func updateNextButton(isAnalyzing: Bool) {
+    // isAnalyzing이 false일 때(분석 완료) 버튼 활성화
+    nextButton.isEnabled = !isAnalyzing
+    
+    if isAnalyzing {
+      nextButton.backgroundColor = .primaryTransparent
+      nextButton.setTitleColor(.gray, for: .disabled)
+    } else {
+      nextButton.backgroundColor = .primary
+      nextButton.setTitleColor(.white, for: .normal)
+    }
+  }
+}
+
+// MARK: - Settings
+private extension EmotionAnalyzeView {
+  func setupViews() {
+    [characterImageView, descriptionLabel, nextButton].forEach {
+      addSubview($0)
+    }
+  }
+  
+  func setupLayoutConstraints() {
+    characterImageView.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.top.equalToSuperview().offset(screenHeight * LayoutConstants.characterImageTopRatio)
+      $0.width.height.equalTo(LayoutConstants.characterImageSize)
+    }
+    
+    descriptionLabel.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.top.equalTo(characterImageView.snp.bottom).offset(LayoutConstants.paddingInset)
+    }
+    
+    nextButton.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(LayoutConstants.paddingInset)
+      $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-LayoutConstants.paddingInset)
+      $0.height.equalTo(LayoutConstants.buttonHeight)
+    }
+  }
+  
+  func setupActions() {
+    nextButton.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
+  }
+  
+  @objc private func nextButtonTapped() {
+    delegate?.buttonDidTap(self)
+  }
+}
+
+// MARK: - Constants
+private extension EmotionAnalyzeView {
+  enum LayoutConstants {
+    static let body1: CGFloat = 16
+    
+    static let buttonHeight: CGFloat = 50
+    static let characterImageSize: CGFloat = 250
+    
+    static let characterImageTopRatio: CGFloat = 0.3
+    static let paddingInset: CGFloat = 16
+  }
+}

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
@@ -1,0 +1,65 @@
+//
+//  EmotionAnalyzeViewController.swift
+//  Presentation
+//
+//  Created by 박성근 on 11/23/24.
+//
+
+import Domain
+import UIKit
+
+final class EmotionAnalyzeViewController: BaseViewController<EmotionAnalyzeViewModel>, Coordinatable {
+  // MARK: - UIComponents
+  private let contentView = EmotionAnalyzeView()
+  
+  // MARK: - Properties
+  weak var coordinator: DefaultEmotionAnalyzeRecordCoordinator?
+  
+  // MARK: - LifeCycle
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupViews()
+    setupLayoutConstraints()
+    contentView.delegate = self
+    // TODO: setupNavigationBar()
+    viewModel.action(.analyze)
+  }
+  
+  override func setupViews() {
+    super.setupViews()
+    view.addSubview(contentView)
+  }
+  
+  override func setupLayoutConstraints() {
+    super.setupLayoutConstraints()
+    contentView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+  
+  // TODO: override func setupNavigationBar() { }
+  
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    coordinator?.didFinish()
+  }
+  
+  override func bindState() {
+    super.bindState()
+    
+    viewModel.$state
+      .map(\.isAnalyzing)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] isAnalyzing in
+        self?.contentView.updatedescriptionLabel(isAnalyzing: isAnalyzing)
+        self?.contentView.updateNextButton(isAnalyzing: isAnalyzing)
+      }
+      .store(in: &cancellable)
+  }
+}
+
+extension EmotionAnalyzeViewController: EmotionAnalyzeViewDelegate {
+  func buttonDidTap(_ emotionAnalyzeView: EmotionAnalyzeView) {
+    // TODO: 분석 결과로 이동
+  }
+}

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
@@ -60,6 +60,6 @@ final class EmotionAnalyzeViewController: BaseViewController<EmotionAnalyzeViewM
 
 extension EmotionAnalyzeViewController: EmotionAnalyzeViewDelegate {
   func buttonDidTap(_ emotionAnalyzeView: EmotionAnalyzeView) {
-    // TODO: 분석 결과로 이동
+    // TODO: 분석 결과로 이동 (Emotion, EmotionReport, Voice)
   }
 }

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/View/EmotionAnalyzeViewController.swift
@@ -60,6 +60,6 @@ final class EmotionAnalyzeViewController: BaseViewController<EmotionAnalyzeViewM
 
 extension EmotionAnalyzeViewController: EmotionAnalyzeViewDelegate {
   func buttonDidTap(_ emotionAnalyzeView: EmotionAnalyzeView) {
-    // TODO: 분석 결과로 이동 (Emotion, EmotionReport, Voice)
+    // TODO: 분석 결과로 이동 (Diary를 보냄) -> diaryData()
   }
 }

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/ViewModel/EmotionAnalyzeViewModel.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/ViewModel/EmotionAnalyzeViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  EmotionAnalyzeViewModel.swift
+//  Presentation
+//
+//  Created by 박성근 on 11/23/24.
+//
+
+import Combine
+import Core
+import Domain
+import Foundation
+
+final class EmotionAnalyzeViewModel: ViewModel {
+  // MARK: - Properties
+  enum Action {
+    case analyze // CoreML로 감정 분석, GEMINI를 이용한 답장 받기를 동시에 수행
+  }
+  
+  struct State {
+    var isAnalyzing: Bool
+    var emotion: Emotion // isAnalyzing이 false가 된 후 emotion, heimReply를 VC로 전달하기 위함.
+    var heimReply: EmotionReport
+  }
+  
+  private let recognizedText: String // RecordView에서 넘어온 인식된 텍스트
+  @Published var state: State
+  private let classifyUseCase: EmotionClassifyUseCase
+  // TODO: GEMINI 이용 UseCase 추가
+  
+  init(
+    recognizedText: String,
+    classifyUseCase: EmotionClassifyUseCase
+    // TODO: GEMINI 이용 UseCase 추가
+  ) {
+    self.recognizedText = recognizedText
+    self.state = State(isAnalyzing: true, emotion: .none, heimReply: EmotionReport.init(text: ""))
+    self.classifyUseCase = classifyUseCase
+  }
+  
+  func action(_ action: Action) {
+    Task {
+      async let emotionResult = classifyUseCase.validate(recognizedText) // 2개의 구조적 동시성 작업을 위해 async let을 사용
+      
+      // TODO: GEMINI UseCase 추가. 아래는 예시로 더미데이터를 사용, 삭제 예정
+      let heimResult = EmotionReport(text: "으어어어")
+      
+      do {
+        let (emotion, heimReply) = try await (emotionResult, heimResult)
+        state.emotion = emotion
+        state.heimReply = heimReply
+        
+        sleep(5) // GEMINI의 응답이 5초 걸린다고 가정
+        
+        // 모든 작업이 완료되면 isAnalyzing을 false로 설정
+        state.isAnalyzing = false
+      } catch {
+        // TODO: 에러 처리
+        state.isAnalyzing = false
+      }
+    }
+  }
+}

--- a/Heim/Presentation/Presentation/Record/EmotionAnalyze/ViewModel/EmotionAnalyzeViewModel.swift
+++ b/Heim/Presentation/Presentation/Record/EmotionAnalyze/ViewModel/EmotionAnalyzeViewModel.swift
@@ -23,16 +23,20 @@ final class EmotionAnalyzeViewModel: ViewModel {
   }
   
   private let recognizedText: String // RecordView에서 넘어온 인식된 텍스트
-  @Published var state: State
+  private let voice: Voice // RecordView에서 넘어온 음성 녹음
   private let classifyUseCase: EmotionClassifyUseCase
+  
+  @Published var state: State
   // TODO: GEMINI 이용 UseCase 추가
   
   init(
     recognizedText: String,
+    voice: Voice,
     classifyUseCase: EmotionClassifyUseCase
     // TODO: GEMINI 이용 UseCase 추가
   ) {
     self.recognizedText = recognizedText
+    self.voice = voice
     self.state = State(isAnalyzing: true, emotion: .none, heimReply: EmotionReport.init(text: ""))
     self.classifyUseCase = classifyUseCase
   }
@@ -58,5 +62,9 @@ final class EmotionAnalyzeViewModel: ViewModel {
         state.isAnalyzing = false
       }
     }
+  }
+  
+  func voiceData() -> Voice {
+    return voice
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈 번호 ex) #이슈번호
- #52 
<br>

# 📘 작업 유형
 - [x] 화면 UI
 - [x] 기능 연결

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - 감정 분석(2-1) 화면 UI를 구현하였습니다.
 - 감정 분석에서 실행되는 UseCase들과 ViewModel을 연결하였습니다.
    - GEMINI를 사용하는 부분은 TODO로 표시하였습니다.

- Task가 실행중일 때 보여지는 애니메이션은 확정나지 않아 구현하지 않았습니다.
<br>

# 실행 화면
- GEMINI를 사용하는 시각은 약 5초로 설정하였습니다. -> sleep(5)로 설정

https://github.com/user-attachments/assets/b31b32cb-cff6-4f7d-9821-db5542bad7c1

# 📝 특이 사항 (Optional)
- #54 
-  위의 구현사항에서 나타난 것과 같이, 감정 분석 화면에서는 인식된 텍스트, voice 데이터를 가지고 있어야 합니다.
    - viewModel을 선언할 때 `인식된 텍스트, voice, UseCase' 를 파라미터로 넣어줍니다.
    ```
    let viewModel = EmotionAnalyzeViewModel(
      recognizedText: text,
      voice: voice,
      classifyUseCase: emotionClassfiyUseCase
    )
    ```
    - 이후 다음 화면으로 넘어갈 때는 `인식된 텍스트, voice, 하임이의 답장` 이 들어가므로 아래와 같이 프로토콜을 정의하였습니다.
    ```
    public protocol EmotionAnalyzeCoordinator: Coordinator {
       ...
       func pushDiaryReportView(emotion: Emotion, heimReply: EmotionReport, voice: Voice)
    }
    ```