### PR TITLE
[Feat] Implement Spotify Recommendation API

### DIFF
--- a/Heim/DataModule/DataModule/API/SpotifyAPI.swift
+++ b/Heim/DataModule/DataModule/API/SpotifyAPI.swift
@@ -1,0 +1,57 @@
+//
+//  SpotifyAPI.swift
+//  DataModule
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Domain
+import Foundation
+
+enum SpotifyAPI {
+  case recommendations(
+    dto: SpotifyRecommendRequestDTO,
+    accessToken: String
+  )
+}
+
+extension SpotifyAPI: RequestTarget {
+  var baseURL: String {
+    return SpotifyEnvironment.apiBaseURL
+  }
+  
+  var path: String {
+    switch self {
+    case .recommendations:
+      return "/v1/recommendations"
+    }
+  }
+  
+  var method: HTTPMethod {
+    switch self {
+    case .recommendations:
+      return .get
+    }
+  }
+  
+  var headers: [String : String] {
+    switch self {
+    case .recommendations(_, let token):
+      return ["Authorization": "Bearer \(token)"]
+    }
+  }
+  
+  var body: (any Encodable)? {
+    switch self {
+    case .recommendations:
+      return nil
+    }
+  }
+  
+  var query: [String : Any] {
+    switch self {
+    case .recommendations(let dto, _):
+      return dto.dictionary
+    }
+  }
+}

--- a/Heim/DataModule/DataModule/API/SpotifyOAuthAPI.swift
+++ b/Heim/DataModule/DataModule/API/SpotifyOAuthAPI.swift
@@ -48,7 +48,7 @@ extension SpotifyOAuthAPI: RequestTarget {
   
   var query: [String: Any] {
     switch self {
-    case .authorize(let dto): dto.toSnakeCaseDictionary()
+    case .authorize(let dto): dto.dictionary
     case .accessToken: [:]
     }
   }

--- a/Heim/DataModule/DataModule/Repository/DefaultSpotifyRepository.swift
+++ b/Heim/DataModule/DataModule/Repository/DefaultSpotifyRepository.swift
@@ -1,0 +1,34 @@
+//
+//  DefaultSpotifyRepository.swift
+//  DataModule
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Domain
+
+public struct DefaultSpotifyRepository: SpotifyRepository {
+  private let networkProvider: NetworkProvider
+  private let tokenStorage: TokenStorage
+  
+  public init(
+    networkProvider: NetworkProvider,
+    tokenStorage: TokenStorage
+  ) {
+    self.networkProvider = networkProvider
+    self.tokenStorage = tokenStorage
+  }
+  
+  public func fetchRecommendationTrack(_ emotion: Emotion) async throws -> [Track] {
+    guard let accessToken = tokenStorage.load(attrAccount: SpotifyEnvironment.accessTokenAttributeKey) else {
+      throw StorageError.readError
+    }
+    return try await networkProvider.request(
+      target: SpotifyAPI.recommendations(
+        dto: SpotifyRecommendRequestDTOFactory.shared.make(emotion),
+        accessToken: accessToken
+      ),
+      type: SpotifyRecommendResponseDTO.self
+    ).tracks.map { SpotifyTrack.toEntity($0) }
+  }
+}

--- a/Heim/DataModule/DataModule/ResponseDTO/SpotifyRecommendResponseDTO.swift
+++ b/Heim/DataModule/DataModule/ResponseDTO/SpotifyRecommendResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  SpotifyRecommendResponseDTO.swift
+//  DataModule
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Domain
+
+struct SpotifyRecommendResponseDTO: Codable {
+  let tracks: [SpotifyTrack]
+  let seeds: [Seed]
+}

--- a/Heim/Domain/Domain/Entity/Seed.swift
+++ b/Heim/Domain/Domain/Entity/Seed.swift
@@ -1,0 +1,21 @@
+//
+//  Seed.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+public struct Seed: Codable {
+  public let id: String
+  public let type: String
+  public let initialPoolSize: Int
+  public let afterFilteringSize: Int
+  public let afterRelinkingSize: Int
+  
+  enum CodingKeys: String, CodingKey {
+    case id, type
+    case initialPoolSize = "initialPoolSize"
+    case afterFilteringSize = "afterFilteringSize"
+    case afterRelinkingSize = "afterRelinkingSize"
+  }
+}

--- a/Heim/Domain/Domain/Entity/SpotifyTrack.swift
+++ b/Heim/Domain/Domain/Entity/SpotifyTrack.swift
@@ -1,0 +1,75 @@
+//
+//  SpotifyTrack.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+public struct SpotifyTrack: Codable {
+  public let album: Album
+  public let artists: [Artist]
+  public let id: String
+  public let name: String
+  public let durationMS: Int
+  public let explicit: Bool
+  public let popularity: Int
+  public let previewURL: String?
+  public let uri: String
+  public let externalIDs: ExternalIDs
+  
+  enum CodingKeys: String, CodingKey {
+    case album, artists, id, name
+    case durationMS = "duration_ms"
+    case explicit, popularity
+    case previewURL = "preview_url"
+    case uri
+    case externalIDs = "external_ids"
+  }
+  
+  public static func toEntity(_ spotifyTrack: SpotifyTrack) -> Track {
+    return Track(
+      thumbnail: spotifyTrack.album.albumArtURL,
+      title: spotifyTrack.name,
+      artist: spotifyTrack.artists.map { $0.name }.joined(separator: ", "),
+      isrc: spotifyTrack.externalIDs.isrc
+    )
+  }
+}
+
+public struct Album: Codable {
+  public let id: String
+  public let name: String
+  public let releaseDate: String
+  public let images: [AlbumImage]
+  
+  var albumArtURL: URL? {
+    return images.first?.wrappedURL
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case id, name
+    case releaseDate = "release_date"
+    case images
+  }
+}
+
+public struct AlbumImage: Codable {
+  public let url: String
+  public let height: Int
+  public let width: Int
+  
+  var wrappedURL: URL? {
+    return URL(string: url)
+  }
+}
+
+public struct Artist: Codable {
+  public let id: String
+  public let name: String
+}
+
+public struct ExternalIDs: Codable {
+  public let isrc: String
+}

--- a/Heim/Domain/Domain/Entity/Track.swift
+++ b/Heim/Domain/Domain/Entity/Track.swift
@@ -1,0 +1,15 @@
+//
+//  Track.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+public struct Track {
+  public let thumbnail: URL?
+  public let title: String
+  public let artist: String
+  public let isrc: String
+}

--- a/Heim/Domain/Domain/Error/EmotionError.swift
+++ b/Heim/Domain/Domain/Error/EmotionError.swift
@@ -1,0 +1,19 @@
+//
+//  EmotionError.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+public enum EmotionError: Error {
+  case noneEmotionException
+  
+  var description: String {
+    switch self {
+    case .noneEmotionException:
+      return "잘못된 감정"
+    }
+  }
+}

--- a/Heim/Domain/Domain/Interface/Repository/SpotifyRepository.swift
+++ b/Heim/Domain/Domain/Interface/Repository/SpotifyRepository.swift
@@ -1,0 +1,10 @@
+//
+//  SpotifyRepository.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+public protocol SpotifyRepository {
+  func fetchRecommendationTrack(_ emotion: Emotion) async throws -> [Track]
+}

--- a/Heim/Domain/Domain/RequestDTO/DictionaryRepresentable.swift
+++ b/Heim/Domain/Domain/RequestDTO/DictionaryRepresentable.swift
@@ -1,0 +1,48 @@
+//
+//  DictionaryRepresentable.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+/// 해당 프로젝트에서 query는 Dictonary로 설계되었지만,
+/// 너무 많은 parameter를 사용하는 경우 DTO로 구현하기 위해 설계되었습니다.
+///
+/// 현재 snake_case를 사용하는 경우에만 구현이 되어 있습니다.
+/// 필요 시 camelCase 또는 PascalCase에도 구현할 수 있습니다.
+protocol DictionaryRepresentable {
+  var dictionary: [String: Any] { get }
+}
+
+extension DictionaryRepresentable {
+  func toSnakeCaseDictionary() -> [String: Any] {
+    var dict = [String: Any]()
+    let mirror = Mirror(reflecting: self)
+    
+    for child in mirror.children {
+      if let key = child.label {
+        dict[key.toSnakeCase()] = child.value
+      }
+    }
+    return dict
+  }
+}
+
+// MARK: - String extension
+private extension String {
+  func toSnakeCase() -> String {
+    guard !isEmpty else { return self }
+    var result = ""
+    for char in self {
+      if char.isUppercase {
+        result.append("_")
+        result.append(char.lowercased())
+      } else {
+        result.append(char)
+      }
+    }
+    return result.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+  }
+}

--- a/Heim/Domain/Domain/RequestDTO/SpotifyAuthorizeRequestDTO.swift
+++ b/Heim/Domain/Domain/RequestDTO/SpotifyAuthorizeRequestDTO.swift
@@ -7,13 +7,7 @@
 
 import Foundation
 
-/// SpotifyAuthorizeRequestDTO는 query를 위한 DTO입니다.
-/// 해당 프로젝트에서 query는 Dictonary로 설계되었지만,
-/// 너무 많은 parameter를 사용하므로 DTO로 구현합니다.
-///
-/// 사용 시 인스턴스를 생성하고 .toSnakeCaseDictionary를 사용하세요.
-/// - 해당 API가 요구하는 파라미터의 네이밍은 snake_case로 되어있습니다.
-public struct SpotifyAuthorizeRequestDTO {
+public struct SpotifyAuthorizeRequestDTO: DictionaryRepresentable {
   private let responseType: String
   private let clientId: String
   private let codeChallengeMethod: String
@@ -34,32 +28,7 @@ public struct SpotifyAuthorizeRequestDTO {
     self.redirectUri = redirectUri
   }
   
-  public func toSnakeCaseDictionary() -> [String: Any] {
-    var dict = [String: Any]()
-    let mirror = Mirror(reflecting: self)
-    
-    for child in mirror.children {
-      if let key = child.label {
-        dict[key.toSnakeCase()] = child.value
-      }
-    }
-    return dict
-  }
-}
-
-// MARK: - String extension
-private extension String {
-  func toSnakeCase() -> String {
-    guard !isEmpty else { return self }
-    var result = ""
-    for char in self {
-      if char.isUppercase {
-        result.append("_")
-        result.append(char.lowercased())
-      } else {
-        result.append(char)
-      }
-    }
-    return result.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+  public var dictionary: [String : Any] {
+    return self.toSnakeCaseDictionary()
   }
 }

--- a/Heim/Domain/Domain/RequestDTO/SpotifyRecommendRequestDTO.swift
+++ b/Heim/Domain/Domain/RequestDTO/SpotifyRecommendRequestDTO.swift
@@ -1,0 +1,87 @@
+//
+//  SpotifyRecommendRequestDTO.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+/// Spotify - Recommendation API
+///
+/// seed* 파라미터들은 필수입니다. 이 3개의 파라미터를 조합하여 최대 5개까지 작성할 수 있습니다.
+/// 앞선 조건에 따라 최소 1개 이상의 파라미터를 채워야 합니다. 이 3개의 파라미터를 조합한 결과가 있어야 하므로 Required로 분류합니다.
+///
+/// 만약 2개 이상의 값을 넣는 경우 쉼표로 구분하여 하나의 String으로 만듭니다.
+/// 3개 모두 채워지지 않아도 됩니다. 단 최소 한개의 파라미터는 채워져야 하며, 사용하지 않는 파라미터는 nil로 비웁니다.
+public struct SpotifyRecommendRequestDTO: DictionaryRepresentable {
+  // Required Parameters
+  private let seedArtists: String?
+  private let seedGenres: String?
+  private let seedTracks: String?
+  
+  // Optional Parameters - Min
+  private let minEnergy: Double?
+  private let minDanceability: Double?
+  private let minTempo: Double?
+  private let minValence: Double?
+  
+  // Optional Parameters - Max
+  private let maxEnergy: Double?
+  private let maxTempo: Double?
+  private let maxValence: Double?
+  
+  // Optional Parameters - Target
+  private let targetAcousticness: Double?
+  private let targetDanceability: Double?
+  private let targetEnergy: Double?
+  private let targetLiveness: Double?
+  private let targetLoudness: Double?
+  private let targetSpeechiness: Double?
+  private let targetTempo: Double?
+  private let targetValence: Double?
+  
+  public init(
+    seedArtists: String? = nil,
+    seedGenres: String? = nil,
+    seedTracks: String? = nil,
+    minEnergy: Double? = nil,
+    minDanceability: Double? = nil,
+    minTempo: Double? = nil,
+    minValence: Double? = nil,
+    maxEnergy: Double? = nil,
+    maxTempo: Double? = nil,
+    maxValence: Double? = nil,
+    targetAcousticness: Double? = nil,
+    targetDanceability: Double? = nil,
+    targetEnergy: Double? = nil,
+    targetLiveness: Double? = nil,
+    targetLoudness: Double? = nil,
+    targetSpeechiness: Double? = nil,
+    targetTempo: Double? = nil,
+    targetValence: Double? = nil
+  ) {
+    self.seedArtists = seedArtists
+    self.seedGenres = seedGenres
+    self.seedTracks = seedTracks
+    self.minEnergy = minEnergy
+    self.minDanceability = minDanceability
+    self.minTempo = minTempo
+    self.minValence = minValence
+    self.maxEnergy = maxEnergy
+    self.maxTempo = maxTempo
+    self.maxValence = maxValence
+    self.targetAcousticness = targetAcousticness
+    self.targetDanceability = targetDanceability
+    self.targetEnergy = targetEnergy
+    self.targetLiveness = targetLiveness
+    self.targetLoudness = targetLoudness
+    self.targetSpeechiness = targetSpeechiness
+    self.targetTempo = targetTempo
+    self.targetValence = targetValence
+  }
+  
+  public var dictionary: [String: Any] {
+    return self.toSnakeCaseDictionary()
+  }
+}

--- a/Heim/Domain/Domain/RequestDTO/SpotifyRecommendRequestDTOFactory.swift
+++ b/Heim/Domain/Domain/RequestDTO/SpotifyRecommendRequestDTOFactory.swift
@@ -1,0 +1,88 @@
+//
+//  SpotifyRecommendRequestDTOFactory.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+public final class SpotifyRecommendRequestDTOFactory {
+  public static let shared = SpotifyRecommendRequestDTOFactory()
+  
+  public func make(_ emotion: Emotion) throws -> SpotifyRecommendRequestDTO {
+    switch emotion {
+    case .angry:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "metal",
+        minEnergy: 0.8,
+        maxValence: 0.4,
+        targetAcousticness: 0.1,
+        targetLoudness: -5,
+        targetSpeechiness: 0.3,
+        targetTempo: 160
+      )
+    case .disgust:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "blues",
+        minEnergy: 0.2,
+        maxEnergy: 0.6,
+        targetLoudness: -18,
+        targetSpeechiness: 0.4,
+        targetTempo: 80,
+        targetValence: 0.3
+      )
+    case .fear:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "soundtrack",
+        minEnergy: 0.1,
+        maxValence: 0.3,
+        targetAcousticness: 0.5,
+        targetLoudness: -25,
+        targetSpeechiness: 0.6
+      )
+    case .happiness:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "pop",
+        minEnergy: 0.7,
+        minDanceability: 0.7,
+        maxEnergy: 1.0,
+        targetLiveness: 0.2,
+        targetTempo: 120,
+        targetValence: 0.9
+      )
+    case .neutral:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "chill",
+        targetAcousticness: 0.4,
+        targetDanceability: 0.5,
+        targetEnergy: 0.5,
+        targetTempo: 100,
+        targetValence: 0.5
+      )
+    case .sadness:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "acoustic",
+        minEnergy: 0.1,
+        minValence: 0.1,
+        maxEnergy: 0.4,
+        maxValence: 0.3,
+        targetAcousticness: 0.8,
+        targetLoudness: -20,
+        targetTempo: 65
+      )
+    case .surprise:
+      return SpotifyRecommendRequestDTO(
+        seedGenres: "edm",
+        minEnergy: 0.5,
+        minTempo: 120,
+        maxEnergy: 0.9,
+        maxTempo: 150,
+        targetLiveness: 0.8,
+        targetValence: 0.6
+      )
+    case .none:
+      throw EmotionError.noneEmotionException
+    }
+  }
+}

--- a/Heim/Domain/Domain/UseCase/MusicUseCase.swift
+++ b/Heim/Domain/Domain/UseCase/MusicUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  MusicUseCase.swift
+//  Domain
+//
+//  Created by 정지용 on 11/25/24.
+//
+
+import Foundation
+
+public protocol MusicUseCase {
+  func fetchRecommendTracks(_ emotion: Emotion) async throws -> [Track]
+  func play(to isrc: String)
+}
+
+public struct DefaultMusicUseCase: MusicUseCase {
+  private let repository: SpotifyRepository
+  
+  public init(repository: SpotifyRepository) {
+    self.repository = repository
+  }
+  
+  public func fetchRecommendTracks(_ emotion: Emotion) async throws -> [Track] {
+    return try await repository.fetchRecommendationTrack(emotion)
+  }
+  
+  // TODO: MusicKit 연동 후 구현
+  public func play(to isrc: String) {
+    
+  }
+}


### PR DESCRIPTION
### 📌 관련 이슈 번호 
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/40
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/73

<br>

# 📘 작업 유형
 - [x] 신규 기능 추가
 - [x] 리팩토링

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - DictionaryRepresentable 추가
   - DTO를 Dictionary로 변환할 수 있는 능력? 제공
   - 자세한 내용은 코드의 주석 참고
 - 감정에 맞는 요청을 생성하기 위한 Factory 추가
 - Get Recommendations 관련 기능 구현
   - https://developer.spotify.com/documentation/web-api/reference/get-recommendations

<br>

### 📝 특이 사항 (Optional)
 - DTO Factory 관련해서 확신이 안 들어서 확인해주시면 감사드리겠습니다.