### PR TITLE
[Design] 음악추천 뷰 리팩토링

### DIFF
--- a/Heim/Presentation/Presentation/Music/Coordinator/MusicMatchCoordinator.swift
+++ b/Heim/Presentation/Presentation/Music/Coordinator/MusicMatchCoordinator.swift
@@ -43,8 +43,9 @@ public final class DefaultMusicMatchCoordinator: MusicMatchCoordinator {
 // MARK: - Private
 private extension DefaultMusicMatchCoordinator {
   func createMusicMatchViewController() -> MusicMatchViewController? {
-    // TODO: 수정 
-    let viewController = MusicMatchViewController(musics: [Music(title: "Supernova", artist: "aespa")])
+    // TODO: 수정
+    let viewModel = MusicMatchViewModel()
+    let viewController = MusicMatchViewController(musics: [Music(title: "Supernova", artist: "aespa")], viewModel: viewModel)
     viewController.coordinator = self
     return viewController
   }

--- a/Heim/Presentation/Presentation/Music/Coordinator/MusicMatchCoordinator.swift
+++ b/Heim/Presentation/Presentation/Music/Coordinator/MusicMatchCoordinator.swift
@@ -10,7 +10,7 @@ import Domain
 import UIKit
 
 public protocol MusicMatchCoordinator: Coordinator {
-  func pushHomeView()
+  func backToMainView()
 
 }
 
@@ -35,7 +35,9 @@ public final class DefaultMusicMatchCoordinator: MusicMatchCoordinator {
     parentCoordinator?.removeChild(self)
   }
 
-  public func pushHomeView() {
+  public func backToMainView() {
+    didFinish()
+    navigationController.popToRootViewController(animated: true)
   }
 
 }

--- a/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
+++ b/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
@@ -13,7 +13,7 @@ struct Music {
   let artist: String
 }
 
-final class MusicMatchViewController: UIViewController, Coordinatable {
+final class MusicMatchViewController: BaseViewController<MusicMatchViewModel>, Coordinatable{
   // MARK: - Properties
   // TODO: let 수정
   private var musicDataSources: [Music]
@@ -21,13 +21,6 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
   weak var coordinator: DefaultMusicMatchCoordinator?
 
   // MARK: - UI Components
-  private let backgroundImageView: UIImageView = {
-    let imageView = UIImageView()
-    imageView.image = .background
-    imageView.contentMode = .scaleAspectFill
-    return imageView
-  }()
-
   private let titleLabel = CommonLabel(text: "하임이가 추천하는 음악을 가져왔어요!", font: .bold, size: LayoutConstants.titleThree)
 
   private let musicTableView: UITableView = {
@@ -53,7 +46,8 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
   }()
 
   // MARK: - Initializer
-  init(musics: [Music], isHiddenHomeButton: Bool = false) {
+  init(musics: [Music], isHiddenHomeButton: Bool = false, viewModel: MusicMatchViewModel) {
+
     self.musicDataSources = musics
     // TODO: 삭제
     self.musicDataSources = [Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태..."),
@@ -63,7 +57,7 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태...")]
 
     self.isHiddenHomeButton = isHiddenHomeButton
-    super.init(nibName: nil, bundle: nil)
+    super.init(viewModel: viewModel)
   }
 
   required init?(coder: NSCoder) {
@@ -78,6 +72,42 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
 
   override func viewDidLayoutSubviews() {
     setupTableViewGradient()
+  }
+
+  override func setupViews() {
+    super.setupViews()
+
+    homeButton.isHidden = isHiddenHomeButton
+    musicTableView.delegate = self
+    musicTableView.dataSource = self
+
+    view.addSubview(titleLabel)
+    view.addSubview(musicTableView)
+    view.addSubview(homeButton)
+
+    homeButton.addTarget(self,
+                     action: #selector(homeButtondidTap),
+                     for: .touchUpInside)
+  }
+
+  override func setupLayoutConstraints() {
+    super.setupLayoutConstraints()
+
+    titleLabel.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.left.equalTo(LayoutConstants.defaultPadding)
+    }
+
+    musicTableView.snp.makeConstraints {
+      $0.top.equalTo(titleLabel.snp.bottom).offset(LayoutConstants.defaultPadding)
+      $0.leading.trailing.equalToSuperview().inset(LayoutConstants.defaultPadding)
+      $0.bottom.equalToSuperview().offset(LayoutConstants.tableViewBottom)
+    }
+
+    homeButton.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(LayoutConstants.defaultPadding)
+      $0.top.equalTo(musicTableView.snp.bottom).offset(LayoutConstants.homeButtonTop)
+    }
   }
 
   @objc func homeButtondidTap() {
@@ -119,8 +149,8 @@ extension MusicMatchViewController: UITableViewDataSource {
 
     return cell
   }
-
 }
+
 private extension MusicMatchViewController {
   enum LayoutConstants {
     static let defaultPadding: CGFloat = 16
@@ -132,43 +162,6 @@ private extension MusicMatchViewController {
   }
 
   // MARK: - Layout
-  func setupViews() {
-    homeButton.isHidden = isHiddenHomeButton
-    musicTableView.delegate = self
-    musicTableView.dataSource = self
-
-    view.addSubview(backgroundImageView)
-    view.addSubview(titleLabel)
-    view.addSubview(musicTableView)
-    view.addSubview(homeButton)
-
-    homeButton.addTarget(self,
-                     action: #selector(homeButtondidTap),
-                     for: .touchUpInside)
-  }
-
-  func setupLayoutConstraints() {
-    backgroundImageView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
-    }
-
-    titleLabel.snp.makeConstraints {
-      $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.left.equalTo(LayoutConstants.defaultPadding)
-    }
-
-    musicTableView.snp.makeConstraints {
-      $0.top.equalTo(titleLabel.snp.bottom).offset(LayoutConstants.defaultPadding)
-      $0.leading.trailing.equalToSuperview().inset(LayoutConstants.defaultPadding)
-      $0.bottom.equalToSuperview().offset(LayoutConstants.tableViewBottom)
-    }
-
-    homeButton.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview().inset(LayoutConstants.defaultPadding)
-      $0.top.equalTo(musicTableView.snp.bottom).offset(LayoutConstants.homeButtonTop)
-    }
-  }
-
   func setupTableViewGradient() {
     let gradientLayer = CAGradientLayer()
     gradientLayer.frame = musicTableView.bounds

--- a/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
+++ b/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
@@ -17,7 +17,6 @@ final class MusicMatchViewController: BaseViewController<MusicMatchViewModel>, C
   // MARK: - Properties
   // TODO: let 수정
   private var musicDataSources: [Music]
-  private let isHiddenHomeButton: Bool
   weak var coordinator: DefaultMusicMatchCoordinator?
 
   // MARK: - UI Components
@@ -56,7 +55,7 @@ final class MusicMatchViewController: BaseViewController<MusicMatchViewModel>, C
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태..."),
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태...")]
 
-    self.isHiddenHomeButton = isHiddenHomeButton
+    self.homeButton.isHidden = isHiddenHomeButton
     super.init(viewModel: viewModel)
   }
 
@@ -77,7 +76,6 @@ final class MusicMatchViewController: BaseViewController<MusicMatchViewModel>, C
   override func setupViews() {
     super.setupViews()
 
-    homeButton.isHidden = isHiddenHomeButton
     musicTableView.delegate = self
     musicTableView.dataSource = self
 

--- a/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
+++ b/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
@@ -107,11 +107,12 @@ final class MusicMatchViewController: BaseViewController<MusicMatchViewModel>, C
     homeButton.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview().inset(LayoutConstants.defaultPadding)
       $0.top.equalTo(musicTableView.snp.bottom).offset(LayoutConstants.homeButtonTop)
+      $0.height.equalTo(LayoutConstants.homeButtonHeight)
     }
   }
 
   @objc func homeButtondidTap() {
-    coordinator?.pushHomeView()
+    coordinator?.backToMainView()
   }
 }
 
@@ -159,6 +160,7 @@ private extension MusicMatchViewController {
     static let homeButtonTop: CGFloat = 32
     static let cornerRadius: CGFloat = 10
     static let tableViewBottom = UIApplication.screenHeight * 170 / UIApplication.screenHeight * -1
+    static let homeButtonHeight = UIApplication.screenHeight * 0.07
   }
 
   // MARK: - Layout

--- a/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
+++ b/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
@@ -17,6 +17,7 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
   // MARK: - Properties
   // TODO: let 수정
   private var musicDataSources: [Music]
+  private let isHiddenHomeButton: Bool
   weak var coordinator: DefaultMusicMatchCoordinator?
 
   // MARK: - UI Components
@@ -52,7 +53,7 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
   }()
 
   // MARK: - Initializer
-  init(musics: [Music]) {
+  init(musics: [Music], isHiddenHomeButton: Bool = false) {
     self.musicDataSources = musics
     // TODO: 삭제
     self.musicDataSources = [Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태..."),
@@ -60,6 +61,8 @@ final class MusicMatchViewController: UIViewController, Coordinatable {
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태..."),
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태..."),
                              Music(title: "슈퍼노바", artist: "#감성힙합#플레이리스트 #해시태그 #해시태...")]
+
+    self.isHiddenHomeButton = isHiddenHomeButton
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -131,6 +134,7 @@ private extension MusicMatchViewController {
 
   // MARK: - Layout
   func setupViews() {
+    homeButton.isHidden = isHiddenHomeButton
     musicTableView.delegate = self
     musicTableView.dataSource = self
 

--- a/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
+++ b/Heim/Presentation/Presentation/Music/View/MusicMatchViewController.swift
@@ -128,8 +128,7 @@ private extension MusicMatchViewController {
     static let homeButtonFont: CGFloat = 18
     static let homeButtonTop: CGFloat = 32
     static let cornerRadius: CGFloat = 10
-    // TODO: extension 수정
-    static let tableViewBottom = UIScreen.main.bounds.height * 170 / UIScreen.main.bounds.height * -1
+    static let tableViewBottom = UIApplication.screenHeight * 170 / UIApplication.screenHeight * -1
   }
 
   // MARK: - Layout

--- a/Heim/Presentation/Presentation/Music/ViewModel/MusicMatchViewModel.swift
+++ b/Heim/Presentation/Presentation/Music/ViewModel/MusicMatchViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  MusicMatchViewModel.swift
+//  Presentation
+//
+//  Created by 김미래 on 11/27/24.
+//
+
+import Combine
+import Core
+import Domain
+
+final class MusicMatchViewModel: ViewModel {
+
+  // MARK: - Properties
+  enum Action {
+    //TODO: 수정
+    case playMusic
+    case pauseMusic
+  }
+
+  struct State: Equatable {
+    var isPlay: Bool
+    var isPause: Bool
+  }
+
+// TODO: UseCase 추가
+  @Published var state: State
+
+  // MARK: - Initializer
+  init() {
+    self.state = State(isPlay: false, isPause: false)
+  }
+
+  func action(_ action: Action) {
+    switch action {
+    case .playMusic:
+      playMusic()
+    case .pauseMusic:
+      pauseMusic()
+    }
+  }
+}
+
+// MARK: - Private Extenion
+private extension MusicMatchViewModel {
+  func playMusic() {}
+  func pauseMusic() {}
+}

--- a/Heim/Presentation/Presentation/Music/ViewModel/MusicMatchViewModel.swift
+++ b/Heim/Presentation/Presentation/Music/ViewModel/MusicMatchViewModel.swift
@@ -19,8 +19,7 @@ final class MusicMatchViewModel: ViewModel {
   }
 
   struct State: Equatable {
-    var isPlay: Bool
-    var isPause: Bool
+    var isPlaying: Bool
   }
 
 // TODO: UseCase 추가
@@ -28,7 +27,7 @@ final class MusicMatchViewModel: ViewModel {
 
   // MARK: - Initializer
   init() {
-    self.state = State(isPlay: false, isPause: false)
+    self.state = State(isPlaying: false)
   }
 
   func action(_ action: Action) {


### PR DESCRIPTION
### 📌 관련 이슈 번호 
- #91 

<br>

# 📘 작업 유형
 - [x] 리팩토링


# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
- Uimain.screen.bounds -> extension으로 바꾸기
- 코드 컨벤션
- homeButton을 hidden 처리
- 뷰모델 생성 

![스크린샷 2024-11-27 오전 3 33 26](https://github.com/user-attachments/assets/3595d458-844f-498a-bbdd-7c4d4fcec03b)
- 버튼이 안보이는 화면으로 만들 수 있도록 refactoring하는 작업 

### 📝 특이 사항 (Optional)
#### viewModel 생성 
- 처음에는 Viewmodel을 생성하지 않았는데, 뮤직킷과 연동되면서 음악재생, 멈춤 등의 버튼에 대한 ui변화를 감지하기 위해서 필요성을 느껴 viewmodel 파일을 생성했습니다. 
- 해당 부분은 아직 미구현 상태이고 뮤직킷 연동하는 작업을 해야합니다. 그럼에도 pr을 올린 이유는 pr 단위를 작게 쪼개서 올리고 싶었기 때문입니다. (미리 파일을 생성해둬야 뒷작업이 편해질 거라고 생각했습니다.     )


#### homeButton을 hidden 처리
- 그리고 음악 추천 뷰는 ```메인으로 돌아가기```버튼을 제외하고 1-2와 2-3의 화면이 동일합니다. 따라서 해당 ViewController은 재사용 될 수 있습니다. 그러기 위해서는 homeButton을 hidden 처리해주면 Viewcontroller의 재사용이 가능해집니다. 
```swift
 private let isHiddenHomeButton: Bool
 init(musics: [Music], isHiddenHomeButton: Bool = false, viewModel: MusicMatchViewModel)
```
- 그에 따라 음악추천ViewController는 isHiddenHomeButton이라는 속성을 가지고 있고, 기본값은 false입니다. 
- isHiddenHomeButton이 true이면 ```메인으로 돌아가기```버튼은 보이지 않습니다. 