### PR TITLE
[Fix] Modify the waveform to reactive

### DIFF
--- a/Heim/Presentation/Presentation/DiaryReplay/Manager/DiaryReplayManager.swift
+++ b/Heim/Presentation/Presentation/DiaryReplay/Manager/DiaryReplayManager.swift
@@ -68,6 +68,71 @@ final class DiaryReplayManager: NSObject, AVAudioPlayerDelegate {
     onPlaybackFinished?()
   }
   
+  func calculateMaxDecibel(completion: @escaping (Float?) -> Void) {
+    guard let audioFileURL,
+          let reader = createAssetReader(for: audioFileURL),
+          let output = reader.outputs.first as? AVAssetReaderTrackOutput else {
+      completion(nil)
+      return
+    }
+    
+    do {
+      let maxDecibel = try calculateMaxDecibel(with: reader, output: output)
+      completion(maxDecibel)
+    } catch {
+      completion(nil)
+    }
+  }
+  
+  private func createAssetReader(for url: URL) -> AVAssetReader? {
+    let asset = AVURLAsset(url: url)
+    guard let track = asset.tracks(withMediaType: .audio).first else { return nil }
+    
+    do {
+      let reader = try AVAssetReader(asset: asset)
+      let settings: [String: Any] = [
+        AVFormatIDKey: kAudioFormatLinearPCM,
+        AVSampleRateKey: 44100,
+        AVLinearPCMBitDepthKey: 16,
+        AVLinearPCMIsNonInterleaved: false,
+        AVLinearPCMIsFloatKey: false,
+        AVLinearPCMIsBigEndianKey: false
+      ]
+      let output = AVAssetReaderTrackOutput(track: track, outputSettings: settings)
+      reader.add(output)
+      return reader
+    } catch {
+      return nil
+    }
+  }
+  
+  private func calculateMaxDecibel(with reader: AVAssetReader, output: AVAssetReaderTrackOutput) throws -> Float {
+    reader.startReading()
+    
+    var maxAmplitude: Float = -160.0
+    while let sampleBuffer = output.copyNextSampleBuffer() {
+      if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+        maxAmplitude = max(maxAmplitude, processBlockBuffer(blockBuffer))
+      }
+    }
+    return maxAmplitude
+  }
+  
+  private func processBlockBuffer(_ blockBuffer: CMBlockBuffer) -> Float {
+    let length = CMBlockBufferGetDataLength(blockBuffer)
+    var data = [Int16](repeating: 0, count: length / MemoryLayout<Int16>.size)
+    CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length, destination: &data)
+    
+    var maxDecibel: Float = -160.0
+    for sample in data {
+      let amplitude = Float(sample) / Float(Int16.max)
+      let decibel = 20 * log10(abs(amplitude))
+      maxDecibel = max(maxDecibel, decibel)
+    }
+    
+    return maxDecibel
+  }
+  
   private func formatTimeIntervalToMMSS(_ time: TimeInterval) -> String {
     let minutes = Int(time) / 60
     let seconds = Int(time) % 60

--- a/Heim/Presentation/Presentation/DiaryReplay/Manager/DiaryReplayManager.swift
+++ b/Heim/Presentation/Presentation/DiaryReplay/Manager/DiaryReplayManager.swift
@@ -11,6 +11,8 @@ import Domain
 final class DiaryReplayManager: NSObject, AVAudioPlayerDelegate {
   let audioPlayer: AVAudioPlayer
   var onPlaybackFinished: (() -> Void)?
+  private(set) var audioFileURL: URL?
+  private var tmpFilePath: URL?
   
   init(data: Data) throws {
     // 1. 오디오 세션 설정
@@ -25,6 +27,7 @@ final class DiaryReplayManager: NSObject, AVAudioPlayerDelegate {
       try data.write(to: tempFile)
       
       // 3. URL로 플레이어 초기화
+      self.audioFileURL = tempFile
       self.audioPlayer = try AVAudioPlayer(contentsOf: tempFile)
       super.init()
       
@@ -33,12 +36,14 @@ final class DiaryReplayManager: NSObject, AVAudioPlayerDelegate {
       self.audioPlayer.delegate = self
       self.audioPlayer.prepareToPlay()
       
-      // 5. 임시 파일 삭제
-      try FileManager.default.removeItem(at: tempFile)
-      
     } catch {
-      throw RecordingError.audioError
+      throw NSError()
     }
+  }
+  
+  deinit {
+    guard let path = tmpFilePath else { return }
+    try? FileManager.default.removeItem(at: path)
   }
   
   var currentTime: String {

--- a/Heim/Presentation/Presentation/DiaryReplay/View/DiaryReplayViewController.swift
+++ b/Heim/Presentation/Presentation/DiaryReplay/View/DiaryReplayViewController.swift
@@ -33,10 +33,16 @@ final class DiaryReplayViewController: BaseViewController<DiaryReplayViewModel> 
     setupActions()
   }
   
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    contentView.setNeedsLayout()
+    contentView.layoutIfNeeded()
+    visualizerView.startVisualizer(for: self.viewModel)
+  }
+  
   override func setupViews() {
     super.setupViews()
     contentView.delegate = self
-    self.visualizerView.startVisualizer(for: self.viewModel)
     view.addSubview(contentView)
   }
   

--- a/Heim/Presentation/Presentation/DiaryReplay/View/VisualizerView.swift
+++ b/Heim/Presentation/Presentation/DiaryReplay/View/VisualizerView.swift
@@ -5,48 +5,66 @@
 //  Created by 정지용 on 11/28/24.
 //
 
+import AVFoundation
 import UIKit
 
 final class VisualizerView: UIView {
   private var displayLink: CADisplayLink?
   private weak var viewModel: DiaryReplayViewModel?
-  private var defaultAmplitude: CGFloat = 0.01
-
+  private var defaultAmplitude: CGFloat = 1
+  private var maxDecibel: Float = -160.0
+  private let totalBars = 30
+  private let amplitudeScalingFactor: CGFloat = 1.5
+  
   func startVisualizer(for viewModel: DiaryReplayViewModel?) {
     self.viewModel = viewModel
     displayLink?.invalidate()
     displayLink = CADisplayLink(target: self, selector: #selector(updateVisualizer))
     displayLink?.add(to: .main, forMode: .common)
+    
+    guard let replayManager = viewModel?.diaryReplayManager else { return }
+    replayManager.calculateMaxDecibel { [weak self] maxDecibel in
+      DispatchQueue.main.async {
+        self?.maxDecibel = max(maxDecibel ?? -160.0, -60)
+      }
+    }
   }
-
+  
   func stopVisualizer() {
     displayLink?.invalidate()
     displayLink = nil
   }
-
+  
   @objc
   private func updateVisualizer() {
     guard let manager = viewModel?.diaryReplayManager else { return }
     
     manager.audioPlayer.updateMeters()
+    
     let power = manager.audioPlayer.averagePower(forChannel: 0)
-    let amplitude = pow(10, power / 20)
-    updateVisualizerPath(amplitude: CGFloat(max(CGFloat(amplitude) * 15, defaultAmplitude)))
+    let amplitude = calculateAmplitude(for: power)
+    updateVisualizerPath(amplitude: amplitude)
   }
-
+  
+  private func calculateAmplitude(for power: Float) -> CGFloat {
+    let maxAmplitude = CGFloat(pow(10, maxDecibel / 20))
+    let currentAmplitude = CGFloat(pow(10, power / 20))
+    let normalizedAmplitude = currentAmplitude / maxAmplitude
+    return max(normalizedAmplitude * bounds.height, defaultAmplitude)
+  }
+  
   private func updateVisualizerPath(amplitude: CGFloat) {
     layer.sublayers?.forEach { $0.removeFromSuperlayer() }
     
     let path = UIBezierPath()
+    let barWidth = bounds.width / CGFloat(totalBars)
+    let maxHeight = bounds.height
     let centerY = bounds.midY
-    let totalBars = 20
-    let barWidth: CGFloat = bounds.width / CGFloat(totalBars)
-    let maxHeight = bounds.height / 5
     
-    for i in 0..<totalBars {
-      let normalizedAmplitude = amplitude * CGFloat.random(in: 0.5...1.5)
-      let barHeight = normalizedAmplitude * maxHeight
-      let xPosition = CGFloat(i) * barWidth
+    for sequence in 0..<totalBars {
+      let randomizedAmplitude = amplitude * CGFloat.random(in: 0.5...amplitudeScalingFactor)
+      let barHeight = min(randomizedAmplitude, maxHeight)
+      let xPosition = CGFloat(sequence) * barWidth
       let barRect = CGRect(
         x: xPosition,
         y: centerY - barHeight / 2,


### PR DESCRIPTION
### 📌 관련 이슈 번호 ex) #이슈번호
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/118
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/121

<br>

# 📘 작업 유형
 - [x] 버그 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - 음원의 최대 데시벨에 따라 파형의 최대 값을 계산하는 로직 추가
   - 정확한 scale 값을 얻기 위해 VisualizerView의 생성 시점 변경
 - 위 기능 연결, scale 값이 반응형으로 지정되어 항상 frame 안에서 파형이 생성되도록 변경 

<br>

### 참고 사항

https://github.com/user-attachments/assets/307bb0ad-f70b-4cbc-9b66-b17d84809803

핫픽스에 가까운 PR입니다. 설계보다는 당장의 버그 수정을 위한 패치이므로, 설계는 Refactor 기간에 수정하도록 하겠습니다.