### PR TITLE
[Fix] Improvements for CoreML accuracy

### DIFF
--- a/Heim/Presentation/Presentation/Interface/Alertable.swift
+++ b/Heim/Presentation/Presentation/Interface/Alertable.swift
@@ -16,6 +16,7 @@ enum AlertType {
   case removeData  // 데이터 삭제
 //  case playError
   case alreadyWrittenDiary
+  case tooShortDiary
 
   var title: String {
     switch self {
@@ -25,6 +26,7 @@ enum AlertType {
     case .removeData: "현재 기기에 저장된 일기가\n모두 사라져요"
 //    case .playError: "재생 중 오류가 발생했습니다."
     case .alreadyWrittenDiary: "이미 일기를 작성했어요"
+    case .tooShortDiary: "일기가 너무 짧아요!"
     }
   }
   
@@ -35,6 +37,7 @@ enum AlertType {
     case .removeCache: "현재 기기에 저장된 일기가 사라져요,\n정말 삭제하시겠어요?"
     case .removeData: "현재 기기에 저장된 일기가 사라져요,\n정말 삭제하시겠어요?"
     case .alreadyWrittenDiary: "일기는 하루에 한 개만 작성할 수 있어요.\n이미 작성한 일기를 삭제해주세요!"
+    case .tooShortDiary: "하임이가 분석을 하기 어려워요.\n더 길게 오늘의 하루를 남겨주시겠어요?"
     }
   }
   
@@ -46,6 +49,7 @@ enum AlertType {
     case .removeData: "닫기"
 //    case .playError: "확인"
     case .alreadyWrittenDiary: "닫기"
+    case .tooShortDiary: "닫기"
     }
   }
   
@@ -57,6 +61,7 @@ enum AlertType {
     case .removeData: "확인"
 //    case .playError: ""
     case .alreadyWrittenDiary: ""
+    case .tooShortDiary: ""
     }
   }
 }

--- a/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
@@ -8,7 +8,7 @@
 import Domain
 import UIKit
 
-public final class RecordViewController: BaseViewController<RecordViewModel>, Coordinatable {
+public final class RecordViewController: BaseViewController<RecordViewModel>, Coordinatable, Alertable {
   // MARK: - UIComponents
   private let contentView = RecordView()
   
@@ -125,12 +125,23 @@ extension RecordViewController: RecordViewDelegate {
 }
 
 private extension RecordViewController {
+  func presentWarning() {
+    presentAlert(
+      type: .tooShortDiary,
+      leftButtonAction: {
+        self.viewModel.action(.refresh)
+      }
+    )
+  }
+  
   func moveToEmotionAnalyzeView() {
     guard let recognizedText = viewModel.recognizedTextData(),
-          let voice = viewModel.voiceData()
-    else {
-      return
-    }
+          let voice = viewModel.voiceData() else { return }
+    if recognizedText.count < 70 { presentWarning(); return }
+    
+    guard let voice = viewModel.voiceData() else { return }
+    print(recognizedText.count)
+    
     removeTemporaryFiles()
     coordinator?.pushEmotionAnalyzeView(recognizedText: recognizedText, voice: voice)
   }

--- a/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
+++ b/Heim/Presentation/Presentation/Record/RecordFeature/View/RecordViewController.swift
@@ -140,7 +140,6 @@ private extension RecordViewController {
     if recognizedText.count < 70 { presentWarning(); return }
     
     guard let voice = viewModel.voiceData() else { return }
-    print(recognizedText.count)
     
     removeTemporaryFiles()
     coordinator?.pushEmotionAnalyzeView(recognizedText: recognizedText, voice: voice)


### PR DESCRIPTION
### 📌 관련 이슈 번호 ex) #이슈번호
- https://github.com/boostcampwm-2024/iOS05-Heim/issues/149
<br>

# 📘 작업 유형
 - [x] 버그 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
- 음성 녹음이 너무 짧으면 정확성이 크게 떨어지는 문제 개선
- 음성 녹음의 길이를 제한 -> 너무 짧은 경우 다시 녹음하도록 수정
  - 50자의 텍스트에서는 감정을 제대로 추출하지 못하는 경우가 많습니다.
  - 위의 이유로 70자의 길이로 제한했는데, 실제로 녹음을 해보면 70자도 꽤나 짧습니다.