### PR TITLE
[Bug] 탭바 탭을 선택할 때 마다 뷰를 새로 그리는 버그 수정

### DIFF
--- a/Heim/Presentation/Presentation/Common/TabBar/Coordinator/TabBarCoordinator.swift
+++ b/Heim/Presentation/Presentation/Common/TabBar/Coordinator/TabBarCoordinator.swift
@@ -39,6 +39,10 @@ public final class DefaultTabBarCoordinator: TabBarCoordinator {
   }
   
   public func setHomeView() {
+    if let lastViewController = tabBarViewController?.children.last, lastViewController is HomeViewController {
+      return
+    }
+    
     guard let defaultHomeCoordinator = DIContainer.shared.resolve(type: HomeCoordinator.self) else { return }
     addChildCoordinator(defaultHomeCoordinator)
     defaultHomeCoordinator.parentCoordinator = self
@@ -58,6 +62,10 @@ public final class DefaultTabBarCoordinator: TabBarCoordinator {
   }
   
   public func setReportView() {
+    if let lastViewController = tabBarViewController?.children.last, lastViewController is ReportViewController {
+      return
+    }
+    
     guard let defaultReportCoordinator = DIContainer.shared.resolve(type: ReportCoordinator.self) else { return }
     addChildCoordinator(defaultReportCoordinator)
     defaultReportCoordinator.parentCoordinator = self


### PR DESCRIPTION
### 📌 관련 이슈 번호

 - #157 

<br>

# 📘 작업 유형
 - [x] 버그 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - TabBarCoordinator에서 탭 선택시 이미 보여지고 있는 화면이면 새로 그리지 않도록 수정

<br>

### 📋 체크리스트 (PR을 올리기 전에 스스로 확인해봐요!)
 - PR 제목에 작업 내용을 요약하여 기재했는가?
 - 코딩컨벤션을 준수하는가?
 - 내 코드에 대해 스스로 검토를 했는가?