### PR TITLE
[Fix] 일기 상세 뷰에서 감정에 맞는 이미지 선택 

### DIFF
--- a/Heim/Presentation/Presentation/Detail/DiaryDetail/View/DiaryDetailView.swift
+++ b/Heim/Presentation/Presentation/Detail/DiaryDetail/View/DiaryDetailView.swift
@@ -98,10 +98,12 @@ final class DiaryDetailView: UIView {
   // MARK: - Public Methods
   func configure(
     date: String,
+    emotion: String,
     description: String,
     content: String
   ) {
     dateLabel.text = date
+    characterImageView.image = UIImage.configureImage(emotion: emotion)
     descriptionLabel.text = description
     textArea.setText(content)
   }

--- a/Heim/Presentation/Presentation/Detail/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Heim/Presentation/Presentation/Detail/DiaryDetail/View/DiaryDetailViewController.swift
@@ -50,6 +50,7 @@ final class DiaryDetailViewController: BaseViewController<DiaryDetailViewModel>,
       .sink { [weak self] state in
         self?.contentView.configure(
           date: state.calendarDate,
+          emotion: state.emotion,
           description: state.description,
           content: state.content
         )

--- a/Heim/Presentation/Presentation/Detail/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
+++ b/Heim/Presentation/Presentation/Detail/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
@@ -20,6 +20,7 @@ final class DiaryDetailViewModel: ViewModel {
   
   struct State: Equatable {
     var calendarDate: String = ""
+    var emotion: String = ""
     var description: String = ""
     var content: String = ""
     var isDeleted: Bool = false
@@ -76,11 +77,13 @@ private extension DiaryDetailViewModel {
     do {
       userName = try await userUseCase.fetchUserName()
       state.calendarDate = "\(diary.calendarDate.year)년 \(diary.calendarDate.month)월 \(diary.calendarDate.day)일"
+      state.emotion = diary.emotion.rawValue
       state.description = diary.emotion.diaryDetailDescription(with: userName)
       state.content = diary.summary.text
     } catch {
       userName = "User"
       state.calendarDate = "\(diary.calendarDate.year)년 \(diary.calendarDate.month)월 \(diary.calendarDate.day)일"
+      state.emotion = diary.emotion.rawValue
       state.description = diary.emotion.diaryDetailDescription(with: userName)
       state.content = diary.summary.text
     }


### PR DESCRIPTION
### 📌 관련 이슈 번호

 - #160 

<br>

# 📘 작업 유형
 - [x] 버그 수정

<br>

# 📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - 일기 상세 뷰에서 감정에 맞는 이미지 선택 
